### PR TITLE
chore: 클라우드 작업 자동화 파일 추가, 시간 타입 기본 타임존 변경

### DIFF
--- a/.github/workflows/backend-check.yaml
+++ b/.github/workflows/backend-check.yaml
@@ -1,0 +1,51 @@
+# GitHub Actions Workflow: 백엔드 정적 분석 및 타입 검사
+# 목적: feature → develop 브랜치로 PR 생성 또는 병합 시 자동 검사 수행
+
+name: Backend Static Analysis & Type Check
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    # 대상 브랜치가 develop일 때만 실행
+    branches: [develop]
+    # backend 폴더 내부 코드가 변경된 경우에만 실행
+    paths:
+      - 'backend/**'
+
+jobs:
+  check-backend:
+    # GitHub Actions가 제공하는 리눅스 환경에서 실행
+    runs-on: ubuntu-latest
+    name: Run Checkstyle and Compile
+
+    steps:
+      # 1. PR의 코드 받아오기 (GitHub에서 checkout)
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # 2. Java 21 설치 (Temurin은 OpenJDK의 공식 배포판 중 하나)
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'         # Java 21로 설정
+          distribution: 'temurin'    # 무료 OpenJDK 배포판
+
+      # 3. Checkstyle 실행 (정적 분석 수행)
+      - name: Run Checkstyle
+        working-directory: ./backend # backend 폴더 기준으로 실행
+        run: ./gradlew checkstyleMain
+
+      # 4. Java 컴파일만 수행 (타입 에러 확인용)
+      - name: Type Check (Compile Only)
+        working-directory: ./backend
+        run: ./gradlew compileJava
+          
+      # 5. 실패 시 Discord 알림 전송
+      - name: Notify Discord on failure
+        if: failure()
+        run: |
+          curl -X POST -H "Content-Type: application/json" \
+          -d '{"content":"🚨 백엔드 정적 분석 또는 타입 검사 실패! PR 확인 필요합니다."}' \
+          ${{ secrets.DISCORD_WEBHOOK_URL }}
+

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,11 +5,13 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$/backend" />
+        <option name="gradleJvm" value="openjdk-21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$/backend" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,9 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.5'
 	id 'io.spring.dependency-management' version '1.1.7'
+
+	id 'checkstyle' //정적 분석 도구 추가
+
 }
 
 group = 'com.tamnara'
@@ -68,3 +71,9 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+checkstyle {
+	toolVersion = '10.3.4' // 버전 수정 가능
+	configFile = file("${rootDir}/config/checkstyle/checkstyle.xml") // ✅ 규칙 파일 경로
+}
+

--- a/backend/config/checkstyle/checkstyle.xml
+++ b/backend/config/checkstyle/checkstyle.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+  ✅ Checkstyle 기본 설정 파일
+  이 파일은 코드 스타일 검사 기준을 정의하며,
+  Gradle의 checkstyleMain task에 의해 적용됨.
+-->
+
+<module name="Checker">
+
+  <!--
+    TreeWalker는 대부분의 코드 검사 규칙들을 포함함.
+    실제 코드 트리를 순회하면서 다양한 룰 적용
+  -->
+  <module name="TreeWalker">
+
+    <!--
+      지역 변수에 final 선언이 가능한데도 하지 않으면 경고
+      ➜ 불변 변수 강조 → 안정적인 코드
+    -->
+    <module name="FinalLocalVariable"/>
+
+    <!--
+      사용되지 않는 import 문이 있을 경우 경고
+      ➜ 불필요한 코드 제거 유도
+    -->
+    <module name="UnusedImports"/>
+
+    <!--
+      import java.util.*; 이런 와일드카드 import를 경고
+      ➜ 명확한 import 유지 (클래스별로 하나씩)
+    -->
+    <module name="AvoidStarImport"/>
+
+  </module>
+</module>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,7 +9,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
 spring.jackson.date-format=yyyy-MM-dd'T'HH:mm:ss
-spring.jackson.time-zone=Asia/Seoul
+spring.jackson.time-zone=UTC
 
 spring.batch.job.enabled=false
 server.virtual-threads.enabled=true


### PR DESCRIPTION
### 반영 브랜치
feat/common-config -> develop

## 작업 내용
#### 클라우드
- 깃허브 트리거에 따른 작업 자동화 파일 추가

#### 백엔드
- `application.properties`: 시간 타입 직렬화/역직렬화 시 기본 타임존을 UTC로 변경