### PR TITLE
fix: WebConfig에 중복 CORS 설정 제거 및 SecurityConfig 옵션 수정

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
@@ -27,7 +27,9 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final UserDetailsServiceImpl userDetailsService;
 
-    private final String FRONTEND_BASE_URL = "http://localhost:5173";
+    private final String FRONTEND_BASE_URL_LOCAL = "http://localhost:5173";
+    private final String FRONTEND_BASE_URL_PROD = "";
+
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -60,7 +62,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(FRONTEND_BASE_URL));
+        config.setAllowedOrigins(List.of(
+                FRONTEND_BASE_URL_LOCAL,
+                FRONTEND_BASE_URL_PROD
+        ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
         config.setAllowCredentials(true);
 

--- a/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
@@ -27,6 +27,8 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final UserDetailsServiceImpl userDetailsService;
 
+    private final String FRONTEND_BASE_URL = "http://localhost:5173";
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
@@ -58,9 +60,8 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedOrigins(List.of(FRONTEND_BASE_URL));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
-        config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/backend/src/main/java/com/tamnara/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/WebConfig.java
@@ -1,20 +1,11 @@
 package com.tamnara.backend.global.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("http://127.0.0.1:5500")
-                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
-                .allowCredentials(true);
-    }
-
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/**")


### PR DESCRIPTION
## 연관된 이슈
#22 #24 

<br/>

## 작업 내용
- [x] WebConfig에서 중복되는 CORS 설정 제거
- [x] CORS 설정에서 setAllowedHeaders 옵션 제거
- [x] CORS 허용 도메인에 개발 및 운영 환경 분리 적용

<br/>

## 상세 내용
### WebConfig에서 중복되는 CORS 설정 제거
`/global/config/WebConfig`
- addCorsMappings 클래스 제거
- Spring Security에서 CORS 설정을 처리하기 위해 WebConfig의 CORS 설정 중복 제거
- WebConfig에서 CORS를 처리할 경우, Security Filter보다 후순위이므로 실제 요청 전에 차단 가능성 존재 

<br/>

### CORS 설정에서 setAllowedHeaders 옵션 제거
`/global/config/SecurityConfig`
- CorsConfigurationSource에서 setAllowedHeaders 옵션 제거
   - `config.setAllowedHeaders("*")`와 `config.setAllowCredentials(true)`를 동시 사용 불가 -> CORS 명세 위반
   - `Access-Control-Allow-Headers: *` =  브라우저에게 모든 헤더(*)를 허용한다.
   - `credentials: true (Allow-Credentials: true)` = 보안을 위해 * 와일드카드(*) 사용을 막는다.

<br/>

### CORS 허용 도메인에 개발 및 운영 환경 분리 적용
`/global/config/SecurityConfig`
- CorsConfigurationSource 클래스의 `config.setAllowedOrigins` 옵션에 변수 추가
- `FRONTED_BASE_URL_LOCAL`: 개발(로컬)용
- `FRONTED_BASE_URL_PROD`: 운영용