### PR TITLE
update: 

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/tamnara/backend/global/jwt/JwtProvider.java
@@ -34,7 +34,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .subject(user.getId().toString())
                 .claim("role", user.getRole().toString())
-                .claim("name", user.getUsername())
+                .claim("username", user.getUsername())
                 .issuedAt(new Date())
                 .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_VALIDITY))
                 .signWith(secretKey)

--- a/backend/src/main/java/com/tamnara/backend/user/service/KakaoService.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/KakaoService.java
@@ -34,7 +34,7 @@ public class KakaoService {
     private String redirectUri;
 
     public String buildKakaoLoginUrl() {
-        return UriComponentsBuilder.fromHttpUrl("https://kauth.kakao.com/oauth/authorize")
+        return UriComponentsBuilder.fromUriString("https://kauth.kakao.com/oauth/authorize")
                 .queryParam("response_type", "code")
                 .queryParam("client_id", clientId)
                 .queryParam("redirect_uri", redirectUri)
@@ -120,11 +120,12 @@ public class KakaoService {
 
             String tamnaraAccessToken = jwtProvider.createAccessToken(user);
 
-            return ResponseEntity.ok().body(Map.of(
-                    "access_token", tamnaraAccessToken,
-                    "user_id", user.getId(),
-                    "username", user.getUsername()
-            ));
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + tamnaraAccessToken)
+                    .body(Map.of(
+                            "success", true,
+                            "message", "카카오 로그인이 성공적으로 완료되었습니다."
+                    ));
 
         } catch (JsonProcessingException e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## 🔀 PR 제목  
`feat: 카카오 로그인 응답 시 JWT를 Authorization 헤더로 반환하도록 변경`

---

## 📌 개요  
카카오 로그인 성공 시 access token을 응답 바디가 아닌 **HTTP 헤더의 Authorization 필드에 포함**하도록 응답 방식을 변경했습니다.  
또한 사용자 정보를 JWT payload에 포함할 수 있도록 `username` 클레임을 추가했습니다.

---

## ✅ 주요 변경 사항

### 1. `JwtProvider`
- JWT 생성 시 `username` 클레임 추가
```java
.claim("username", user.getUsername())
```

### 2. KakaoService.kakaoLogin()
기존: 응답 바디에 access_token 포함

```
{
  "access_token": "...",
  "user_id": ...,
  "username": "..."
}
```

변경: JWT를 응답 헤더에 포함하고, 바디에는 성공 메시지만 포함

```
Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
{
  "success": true,
  "message": "카카오 로그인이 성공적으로 완료되었습니다."
}
```

```
return ResponseEntity.ok()
    .header(HttpHeaders.AUTHORIZATION, "Bearer " + tamnaraAccessToken)
    .body(Map.of(
        "success", true,
        "message", "카카오 로그인이 성공적으로 완료되었습니다."
    ));
```

### 3. buildKakaoLoginUrl() 개선
`UriComponentsBuilder.fromHttpUrl(...)` → `fromUriString(...)`으로 변경하여 deprecated 이슈 해결

### 💡 추가 안내
프론트엔드에서는 응답 바디가 아닌 헤더의 Authorization 값을 읽어야 합니다!