### PR TITLE
feat: 회원정보조회, 로그아웃, 이메일/닉네임 중복조회 api 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/tamnara/backend/global/jwt/JwtProvider.java
@@ -26,7 +26,6 @@ public class JwtProvider {
     @PostConstruct
     protected void init() {
         // 시크릿 키를 바이트로 인코딩해서 Key 객체로 변환
-        System.out.println("✅ JWT_SECRET_CODE from env: " + secretKeyString); // 임시 출력
         this.secretKey = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
@@ -11,6 +11,7 @@ import com.tamnara.backend.global.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,7 +28,126 @@ public class UserController {
 
     private final UserService userService;
 
+    @GetMapping("/check-email")
+    @Operation(
+            summary = "이메일 중복 조회",
+            description = "입력된 이메일이 이미 가입된 이메일인지 확인합니다. 중복이면 false, 사용 가능하면 true를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청 성공. 사용 가능 여부는 data.available로 확인"),
+            @ApiResponse(responseCode = "400", description = "잘못된 이메일 형식"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<?> checkEmail(@RequestParam("email") String email) {
+        try {
+            if (email == null || !email.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")) {
+                return ResponseEntity.badRequest().body(Map.of(
+                        "success", false,
+                        "message", "이메일 형식이 잘못되었습니다."
+                ));
+            }
+
+            boolean available = userService.isEmailAvailable(email);
+
+            return ResponseEntity.ok(Map.of(
+                    "success", true,
+                    "message", available ? "사용 가능한 이메일입니다." : "이미 사용 중인 이메일입니다.",
+                    "data", Map.of("available", available)
+            ));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
+                    "success", false,
+                    "message", "서버 내부 오류가 발생했습니다. 나중에 다시 시도해주세요."
+            ));
+        }
+    }
+
+    @GetMapping("/check-nickname")
+    @Operation(
+            summary = "닉네임 중복 조회",
+            description = "입력된 닉네임이 이미 가입된 닉네임인지 확인합니다. 중복이면 false, 사용 가능하면 true를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청 성공. 사용 가능 여부는 data.available로 확인"),
+            @ApiResponse(responseCode = "400", description = "잘못된 닉네임 형식"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<?> checkNickname(@RequestParam("nickname") String nickname) {
+        try {
+            // 닉네임 유효성 검증: 영문/한글/숫자 1~10자 이내 등 원하는 규칙에 따라 조정 가능
+            if (nickname == null || nickname.isBlank() || nickname.length() > 10) {
+                return ResponseEntity.badRequest().body(Map.of(
+                        "success", false,
+                        "message", "닉네임 형식이 잘못되었습니다."
+                ));
+            }
+
+            boolean available = userService.isUsernameAvailable(nickname);
+
+            return ResponseEntity.ok(Map.of(
+                    "success", true,
+                    "message", available ? "사용 가능한 닉네임입니다." : "이미 사용 중인 닉네임입니다.",
+                    "data", Map.of("available", available)
+            ));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
+                    "success", false,
+                    "message", "서버 내부 오류가 발생했습니다. 나중에 다시 시도해주세요."
+            ));
+        }
+    }
+
+    @GetMapping("/me")
+    @Operation(
+            summary = "회원 정보 조회",
+            description = "로그인된 사용자의 회원 정보를 반환합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "요청하신 정보를 성공적으로 불러왔습니다."),
+            @ApiResponse(responseCode = "401", description = "로그인이 필요합니다."),
+            @ApiResponse(responseCode = "404", description = "관련된 회원이 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 에러가 발생했습니다.")
+    })
+    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        try {
+            if (userDetails == null || userDetails.getUser() == null) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                        "success", false,
+                        "message", "로그인이 필요합니다."
+                ));
+            }
+
+            Long userId = userDetails.getUser().getId();
+            return ResponseEntity.ok(userService.getCurrentUserInfo(userId));
+
+        } catch (UserNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of(
+                    "success", false,
+                    "message", "관련된 회원이 없습니다."
+            ));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
+                    "success", false,
+                    "message", "서버 내부 에러가 발생했습니다. 나중에 다시 시도해주세요."
+            ));
+        }
+    }
+
     @PatchMapping("/me")
+    @Operation(
+            summary = "회원 정보 수정",
+            description = "로그인된 사용자의 이름을 수정합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 정보가 성공적으로 수정되었습니다."),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 닉네임입니다."),
+            @ApiResponse(responseCode = "404", description = "관련된 회원이 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 에러가 발생했습니다.")
+    })
     public ResponseEntity<?> updateUsername(@RequestBody @Valid UserUpdateRequestDto dto,
                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
@@ -58,4 +178,39 @@ public class UserController {
         }
     }
 
+    @PostMapping("/logout")
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 로그인한 사용자의 access token을 무효화하여 로그아웃 처리합니다.",
+            security = {@SecurityRequirement(name = "bearerAuth")}
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정상적으로 로그아웃되었습니다."),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰입니다."),
+            @ApiResponse(responseCode = "403", description = "유효하지 않은 계정입니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류가 발생했습니다.")
+    })
+    public ResponseEntity<?> logout(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        try {
+            if (userDetails == null || userDetails.getUser() == null) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of(
+                        "success", false,
+                        "message", "유효하지 않은 계정입니다."
+                ));
+            }
+
+            // 서버는 토큰을 저장하지 않기 때문에, 실제로 제거할 작업은 없음
+            // 이 응답만으로 클라이언트는 토큰을 삭제하고 로그아웃 처리
+            return ResponseEntity.ok(Map.of(
+                    "success", true,
+                    "message", "정상적으로 로그아웃되었습니다."
+            ));
+
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
+                    "success", false,
+                    "message", "서버 내부 오류가 발생했습니다. 나중에 다시 시도해주세요."
+            ));
+        }
+    }
 }

--- a/backend/src/main/java/com/tamnara/backend/user/dto/UserEmailCheckResponseDto.java
+++ b/backend/src/main/java/com/tamnara/backend/user/dto/UserEmailCheckResponseDto.java
@@ -1,0 +1,21 @@
+package com.tamnara.backend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserEmailCheckResponseDto {
+    private boolean success;
+    private String message;
+    private Data data;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Data {
+        private boolean available;
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/user/dto/UserInfoResponseDto.java
+++ b/backend/src/main/java/com/tamnara/backend/user/dto/UserInfoResponseDto.java
@@ -1,0 +1,30 @@
+package com.tamnara.backend.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UserInfoResponseDto {
+    private boolean success;
+    private String message;
+    private Data data;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class Data {
+        private UserData user;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class UserData {
+        private Long userId;
+        private String email;
+        private String username;
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/user/service/KakaoService.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/KakaoService.java
@@ -120,6 +120,9 @@ public class KakaoService {
 
             String tamnaraAccessToken = jwtProvider.createAccessToken(user);
 
+            // 콘솔에 access token 출력 (로컬 디버깅용)
+            System.out.println("✅ 발급된 access token: " + tamnaraAccessToken);
+
             return ResponseEntity.ok()
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + tamnaraAccessToken)
                     .body(Map.of(

--- a/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.tamnara.backend.user.domain.State;
 import com.tamnara.backend.user.domain.User;
 import com.tamnara.backend.user.dto.SignupRequestDto;
 import com.tamnara.backend.user.dto.SignupResponseDto;
+import com.tamnara.backend.user.dto.UserInfoResponseDto;
 import com.tamnara.backend.user.exception.DuplicateEmailException;
 import com.tamnara.backend.user.exception.DuplicateUsernameException;
 import com.tamnara.backend.user.exception.UserNotFoundException;
@@ -49,6 +50,35 @@ public class UserService {
                 .message("회원가입이 성공적으로 완료되었습니다.")
                 .data(SignupResponseDto.UserData.builder()
                         .userId(savedUser.getId())
+                        .build())
+                .build();
+    }
+
+    public boolean isEmailAvailable(String email) {
+        return !userRepository.existsByEmail(email);
+    }
+
+    public boolean isUsernameAvailable(String username) {
+        return !userRepository.existsByUsername(username);
+    }
+
+    public UserInfoResponseDto getCurrentUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        if (user.getState() != State.ACTIVE) {
+            throw new UserNotFoundException(); // DELETED나 INACTIVE는 허용하지 않음
+        }
+
+        return UserInfoResponseDto.builder()
+                .success(true)
+                .message("요청하신 정보를 성공적으로 불러왔습니다.")
+                .data(UserInfoResponseDto.Data.builder()
+                        .user(UserInfoResponseDto.UserData.builder()
+                                .userId(user.getId())
+                                .email(user.getEmail())
+                                .username(user.getUsername())
+                                .build())
                         .build())
                 .build();
     }


### PR DESCRIPTION
## 🔐 feat: 회원정보조회, 로그아웃, 이메일/닉네임 중복조회 api 추가

### ✅ 주요 변경 사항

메서드 | URL | 설명
-- | -- | --
GET | `/users/me` | 현재 로그인한 사용자의 정보를 반환 (토큰 기반 인증 필요)
POST | `/users/logout` | 클라이언트 측 토큰 삭제용 로그아웃 요청 처리 (토큰 기반 인증 필요)
GET | `/users/check-email?email={email}` | 이메일 중복 여부 확인
GET | `/users/check-nickname?nickname={nickname}` | 닉네임 중복 여부 확인

---

### 🛡️ 보안 처리 방식
모든 보호된 API는 JWT 기반 인증 필터(JwtAuthenticationFilter)를 통해 유효한 토큰이 있는지 확인

Swagger에서도 Authorize → Bearer {access_token} 방식으로 테스트 가능

Swagger API 문서에는 @SecurityRequirement(name = "bearerAuth")로 인증 필요 여부 명시

---

### 🧪 테스트

- ✅ Postman에서 토큰 발급 및 인증 API (`/users/me`) 테스트 완료
- ✅ Swagger UI에서 `Authorize → Bearer {token}` 입력 후 인증 API 정상 호출 확인

---

### ⚠️ 주의 사항
카카오 로그인 후 JWT access token은 보안상 응답 바디에 포함하지 않고 응답 헤더(Authorization)에 포함됩니다.

Swagger나 Postman에서는 Authorization 헤더 확인이 가능하지만,
브라우저에서 직접 호출 시 CORS 정책상 브라우저에서 응답 헤더를 읽을 수 없습니다.

따라서 현재는 디버깅을 위해 access token을 서버 콘솔에 출력하도록 임시 처리해두었습니다(`KakaoService`):

```
System.out.println("✅ access token: " + tamnaraAccessToken);
```

🚨 운영 배포 전 반드시 제거해야 하며, Logger로 대체하거나 로그 출력 자체를 하지 않아야 합니다.

해당 로그는 단지 프론트 개발/연동 테스트 편의성을 위한 임시 방편입니다.

### 📌 향후 작업 예정

- Refresh Token 전략 도입 여부 논의
- 로그아웃 및 토큰 만료 처리 방식 고도화

