### PR TITLE
update: 핫이슈 뉴스 응답 구조 수정 및 이미지 필드 네이밍 통일, 중복 이미지 대응

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
@@ -43,7 +43,7 @@ public class NewsController {
             return ResponseEntity.ok(Map.of(
                     "success", true,
                     "message", "요청하신 데이터를 성공적으로 불러왔습니다.",
-                    "data", newsCards
+                    "data", Map.of("newsList", newsCards)
             ));
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());

--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsImageRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsImageRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface NewsImageRepository extends JpaRepository<NewsImage, Long> {
-    Optional<NewsImage> findByNewsId(Long newsId);
+    Optional<NewsImage> findFirstByNewsIdOrderByIdAsc(Long newsId);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -420,7 +420,7 @@ public class NewsServiceImpl implements NewsService {
         List<NewsCardDTO> newsCardDTOList = new ArrayList<>();
 
         newsPage.forEach(news -> {
-            Optional<NewsImage> image = newsImageRepository.findByNewsId(news.getId());
+            Optional<NewsImage> image = newsImageRepository.findFirstByNewsIdOrderByIdAsc(news.getId());
             String imageUrl = image.map(NewsImage::getUrl).orElse(null);
 
             String categoryName = news.getCategory() != null ? news.getCategory().getName().toString() : null;


### PR DESCRIPTION
1. `[NewsController.java`의 `findHotissueNews()` 의 응답 객체
    
    `data: Map.of("newsList", newsCards)` 로 감싸서 반환 → API 명세서에 작성된 대로 `data = []` 형태로 프론트에 반환할 수 있음
    
    ```java
    List<NewsCardDTO> newsCards = newsService.getNewsCardPage(...);
    
    // 이전
    return ResponseEntity.ok(Map.of(
        "success", true,
        "message", "요청하신 데이터를 성공적으로 불러왔습니다.",
        "data", newsCards   // ✅ 여기서 직접 배열을 반환함
    )
    
    //수정 후
    return ResponseEntity.ok(Map.of(
        "success", true,
        "message", "요청하신 데이터를 성공적으로 불러왔습니다.",
        "data", Map.of("newsList", newsCards)
    ));
    
    ```
    

1. `newsImageRepository.java` 의 `findByNewsId`
    - 하나의 news id에 대해서 실수로 여러 개의 이미지가 들어갈 경우, `findByNewsId`를 사용하면 서버 에러 → `findFirstByNewsIdOrderByIdAsc`를 사용하여 아이디가 가장 빠른 이미지 하나만 가져오게 함
        
        ```java
        // NewsImageRepository.java
        // 이전
        Optional<NewsImage> findByNewsId(Long newsId);
        
        // 수정 후
        Optional<NewsImage> findFirstByNewsIdOrderByIdAsc(Long newsId);
        ```
        
    - 테스트 코드에 해당 메서드를 사용하는 부분이 있어서 함께 수정 후 commit 하려고 했는데, `permission denied` 에러가 떠서 commit 불가 → 추후 해결 필요
    - main에 있는 코드들은 전부 수정 완료

1. API 명세서의 `GET /news/hotissue` 의 응답 필드 중 image
    
    ```java
    image → imageUrl로 수정
    ```
    
    - 백엔드에서 `NewsCardDTO`로 넘기는 값은 `imageUrl`이라는 이름인데,
    - API 명세서에서는 `image`라는 프로퍼티 이름으로 사용하고 있음 → 해당 이름을 프론트에서 사용했을 때, 백엔드와 매치되지 않아 에러 발생