### PR TITLE
feat: API 명세서와의 불일치 수정 및 핫이슈/일반 뉴스 조회 로직 분리

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
@@ -67,6 +67,7 @@ public class SecurityConfig {
                 FRONTEND_BASE_URL_PROD
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
+        config.setExposedHeaders(List.of("Authorization"));
         config.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
@@ -30,11 +30,10 @@ public class SecurityConfig {
     private final String FRONTEND_BASE_URL_LOCAL = "http://localhost:5173";
     private final String FRONTEND_BASE_URL_PROD = "";
 
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-                .cors(cors -> cors.configure(http))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(httpBasic -> httpBasic.disable())
@@ -63,10 +62,11 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(
-                FRONTEND_BASE_URL_LOCAL,
-                FRONTEND_BASE_URL_PROD
+                FRONTEND_BASE_URL_LOCAL
+//                FRONTEND_BASE_URL_PROD
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         config.setExposedHeaders(List.of("Authorization"));
         config.setAllowCredentials(true);
 

--- a/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
@@ -38,12 +38,13 @@ public class NewsController {
     @GetMapping("/hotissue")
     public ResponseEntity<?> findHotissueNews() {
         try {
-            List<NewsCardDTO> newsCards = newsService.getNewsCardPage(null, true, 0, 3);
+            List<NewsCardDTO> newsCards = newsService.getHotissueNewsCardPage(null);
 
+            Map<String, Object> newsList = Map.of("newsList", newsCards);
             return ResponseEntity.ok(Map.of(
                     "success", true,
                     "message", "요청하신 데이터를 성공적으로 불러왔습니다.",
-                    "data", newsCards
+                    "data", newsList
             ));
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
@@ -75,9 +76,9 @@ public class NewsController {
                     throw new IllegalArgumentException("추가 요청일 경우 offset은 0이어야 합니다.");
                 }
 
-                List<NewsCardDTO> newsCards = newsService.getNewsCardPage(userId, false, category, pageNum, PAGE_SIZE);
+                List<NewsCardDTO> newsCards = newsService.getNormalNewsCardPage(userId, category, pageNum, PAGE_SIZE);
 
-                boolean hasNext = !newsService.getNewsCardPage(userId, false, category, pageNum + 1, PAGE_SIZE).isEmpty();
+                boolean hasNext = !newsService.getNormalNewsCardPage(userId, category, pageNum + 1, PAGE_SIZE).isEmpty();
 
                 Map<String, Object> data = Map.of(
                         category, newsCards,
@@ -96,7 +97,7 @@ public class NewsController {
                     throw new IllegalArgumentException("최초 요청일 경우 offset은 0보다 큰 값이어야 합니다.");
                 }
 
-                Map<String, List<NewsCardDTO>> newsCardsMap = newsService.getNormalNewsCardPages(userId, false, pageNum, PAGE_SIZE);
+                Map<String, List<NewsCardDTO>> newsCardsMap = newsService.getNormalNewsCardPages(userId, pageNum, PAGE_SIZE);
                 Map<String, Object> data = new HashMap<>();
 
                 for (Map.Entry<String, List<NewsCardDTO>> entry : newsCardsMap.entrySet()) {
@@ -105,9 +106,9 @@ public class NewsController {
 
                     boolean hasNext;
                     if (categoryName == "ALL") {
-                        hasNext = newsService.getNewsCardPage(null, false,pageNum + 1, PAGE_SIZE).isEmpty();
+                        hasNext = newsService.getNormalNewsCardPage(null,pageNum + 1, PAGE_SIZE).isEmpty();
                     } else {
-                        hasNext = !newsService.getNewsCardPage(null, false, categoryName, pageNum + 1, PAGE_SIZE).isEmpty();
+                        hasNext = !newsService.getNormalNewsCardPage(null, categoryName, pageNum + 1, PAGE_SIZE).isEmpty();
                     }
 
                     Map<String, Object> categoryData = new HashMap<>();

--- a/backend/src/main/java/com/tamnara/backend/news/dto/NewsCardDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/NewsCardDTO.java
@@ -2,8 +2,6 @@ package com.tamnara.backend.news.dto;
 
 import com.tamnara.backend.news.domain.CategoryType;
 import com.tamnara.backend.news.util.ValueOfEnum;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PastOrPresent;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
@@ -19,7 +17,7 @@ public class NewsCardDTO {
     @Length(max = 36, message = "뉴스의 미리보기 내용은 36자까지만 가능합니다.")
     private String summary;
     @Length(max = 255, message = "이미지 링크의 길이가 너무 깁니다.")
-    private String imageUrl;
+    private String image;
     @ValueOfEnum(enumClass = CategoryType.class, message = "카테고리 값이 올바르지 않습니다.")
     private String category;
     private LocalDateTime updatedAt;

--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
@@ -14,24 +14,19 @@ import java.time.LocalDateTime;
 
 @Repository
 public interface NewsRepository extends JpaRepository<News, Long> {
-    @Query("""
-        SELECT n FROM News n
-        WHERE n.isHotissue = :isHotissue
-        ORDER BY n.updatedAt DESC, n.id DESC
-    """)
-    Page<News> findAllByIsHotissue(@Param("isHotissue") boolean isHotissue, Pageable pageable);
+    Page<News> findAllByIsHotissueTrueOrderByIdAsc(Pageable pageable);
+    Page<News> findByIsHotissueFalseOrderByUpdatedAtDescIdDesc(Pageable pageable);
 
     @Query("""
         SELECT n FROM News n
-        WHERE n.isHotissue = :isHotissue
+        WHERE n.isHotissue = false
           AND (
               (:categoryId IS NULL AND n.category IS NULL)
               OR (:categoryId IS NOT NULL AND n.category.id = :categoryId)
           )
         ORDER BY n.updatedAt DESC, n.id DESC
     """)
-    Page<News> findNewsByIsHotissueAndCategoryId(
-            @Param("isHotissue") boolean isHotissue,
+    Page<News> findByIsHotissueFalseAndCategoryId(
             @Param("categoryId") Long categoryId,
             Pageable pageable
     );

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
@@ -8,9 +8,10 @@ import java.util.List;
 import java.util.Map;
 
 public interface NewsService {
-    List<NewsCardDTO> getNewsCardPage(Long userId, boolean isHotissue, Integer page, Integer size);
-    List<NewsCardDTO> getNewsCardPage(Long userId, boolean isHotissue, String category, Integer page, Integer size);
-    Map<String, List<NewsCardDTO>> getNormalNewsCardPages(Long userId, boolean isHotissue, Integer page, Integer size);
+    List<NewsCardDTO> getHotissueNewsCardPage(Long userId);
+    List<NewsCardDTO> getNormalNewsCardPage(Long userId, Integer page, Integer size);
+    List<NewsCardDTO> getNormalNewsCardPage(Long userId, String category, Integer page, Integer size);
+    Map<String, List<NewsCardDTO>> getNormalNewsCardPages(Long userId, Integer page, Integer size);
     NewsDetailResponse getNewsDetail(Long newsId, Long userId);
     NewsDetailResponse save(Long userId, boolean isHotissue, NewsCreateRequest req);
     NewsDetailResponse update(Long newsId, Long userId);


### PR DESCRIPTION
## 연관된 이슈
#2 #8 #11 

<br/>

## 작업 내용
- [x] API 명세서와의 불일치 수정: 응답 data의 내부 배열 필드명을 newsList로 수정
- [x] API 명세서와의 불일치 수정: newsCardDTO의 이미지 속성명을 imageUrl -> image로 변경
- [x] 핫이슈/일반 뉴스 조회 로직 분리: 핫이슈 뉴스 조회 리포지토리 메서드 추가
- [x] 핫이슈/일반 뉴스 조회 로직 분리: 일반 뉴스 조회 리포지토리 메서드 별도 구성
- [x] 서비스 및 컨트롤러에서 분리된 리포지토리 적용
- [x] 일반 뉴스 조회 로직 일부 수정

<br/>

## 상세 내용
### API 명세서와의 불일치 수정
- 뉴스 컨트롤러에서 응답 data의 내부 배열 필드명을 newsList로 수정
`/news/controller/NewsController`
```java
Map<String, Object> newsList = Map.of("newsList", newsCards);
  return ResponseEntity.ok(Map.of(
    "success", true,
    "message", "요청하신 데이터를 성공적으로 불러왔습니다.",
    "data", newsList
));
```            
- NewsCardDTO의 이미지 속성명을 수정: `imageUrl` -> `image`
`/news/dto/NewsCardDTO`

<br/>

### 핫이슈/일반 뉴스 조회 로직 분리
`/news/repository/NewsRepository`
- 전체 뉴스 조회 시, 핫이슈와 일반 뉴스 조회 메서드 분리 및 핫이슈 조회 시 `id ASC` 정렬 추가
```java
Page<News> findAllByIsHotissueTrueOrderByIdAsc(Pageable pageable);
Page<News> findByIsHotissueFalseOrderByUpdatedAtDescIdDesc(Pageable pageable);
```
- 카테고리 별 일반 뉴스 조회 메서드의 매개변수에서 핫이슈 여부 변수(`isHotissue`) 제거 및 메서드명 수정
```java
@Query("""
        SELECT n FROM News n
        WHERE n.isHotissue = false
          AND (
              (:categoryId IS NULL AND n.category IS NULL)
              OR (:categoryId IS NOT NULL AND n.category.id = :categoryId)
          )
        ORDER BY n.updatedAt DESC, n.id DESC
    """)
Page<News> findByIsHotissueFalseAndCategoryId(
        @Param("categoryId") Long categoryId,
        Pageable pageable
);
```

<br/>

### 일반 뉴스 조회 로직 수정
- offset이 0일 때, 즉 최초 추가 로딩할 경우 예외 처리되는 문제 해결: `offset <= 0` -> `offset < 0`
- 뉴스 카드를 최초 요청할 때
  - offset에 대한 예외 처리 제거
  - 항상 0페이지를 조회하고 offset으로 PAGE_SIZE를 반환하는 일관된 로직 수행
- 카테고리 별 일반 뉴스 조회 시 뉴스 데이터를 저장하는 변수명 변경: `categoryData` -> `categoryNewsData`