### PR TITLE
fix: 뉴스 생성/업데이트 API 연동 테스트 완료

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,6 +62,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+	// AI 연동
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310' // LocalDate를 JSON으로 직렬화
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.batch:spring-batch-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/backend/src/main/java/com/tamnara/backend/global/config/WebClientConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/WebClientConfig.java
@@ -8,10 +8,13 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class WebClientConfig {
+
+    private final String AI_BASE_URL = "http://35.216.120.155:8000/api";
+
     @Bean
     public WebClient aiWebClient() {
         return WebClient.builder()
-                .baseUrl("")
+                .baseUrl(AI_BASE_URL)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }

--- a/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
@@ -13,10 +13,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -53,7 +53,7 @@ public class NewsController {
             throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다.");
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         }
     }
 
@@ -128,7 +128,7 @@ public class NewsController {
             throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다.");
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         }
     }
 
@@ -156,13 +156,13 @@ public class NewsController {
             throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다.");
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         }
     }
 
     @PostMapping
     public ResponseEntity<?> createNews(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                        @ModelAttribute NewsCreateRequest req
+                                        @RequestBody NewsCreateRequest req
     ) {
         try {
             if (userDetails == null || userDetails.getUser() == null) {
@@ -182,7 +182,7 @@ public class NewsController {
             throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다.");
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         }
     }
 
@@ -208,7 +208,7 @@ public class NewsController {
             throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다.");
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         }
     }
 
@@ -239,7 +239,7 @@ public class NewsController {
             throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다.");
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
         }
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/news/dto/NewsCardDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/NewsCardDTO.java
@@ -12,9 +12,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class NewsCardDTO {
     private Long id;
-    @Length(max = 24, message = "뉴스의 제목은 24자까지만 가능합니다.")
+//    @Length(max = 24, message = "뉴스의 제목은 24자까지만 가능합니다.")
     private String title;
-    @Length(max = 36, message = "뉴스의 미리보기 내용은 36자까지만 가능합니다.")
+//    @Length(max = 36, message = "뉴스의 미리보기 내용은 36자까지만 가능합니다.")
     private String summary;
     @Length(max = 255, message = "이미지 링크의 길이가 너무 깁니다.")
     private String image;

--- a/backend/src/main/java/com/tamnara/backend/news/dto/TimelineCardDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/TimelineCardDTO.java
@@ -4,7 +4,6 @@ import com.tamnara.backend.news.domain.TimelineCardType;
 import com.tamnara.backend.news.util.ValueOfEnum;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,7 +11,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class TimelineCardDTO {
-    @Length(max = 18, message = "타임라인 카드의 제목은 24자까지만 가능합니다.")
+//    @Length(max = 18, message = "타임라인 카드의 제목은 18자까지만 가능합니다.")
     private String title;
     private String content;
     private List<String> source;

--- a/backend/src/main/java/com/tamnara/backend/news/dto/WrappedDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/WrappedDTO.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.news.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WrappedDTO<T> {
+    private boolean success;
+    private String message;
+    private T data;
+}

--- a/backend/src/main/java/com/tamnara/backend/news/dto/request/AINewsRequest.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/request/AINewsRequest.java
@@ -1,5 +1,6 @@
 package com.tamnara.backend.news.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,6 +13,8 @@ import java.util.List;
 public class AINewsRequest {
     @Size(min = 1, max = 6, message = "키워드는 최소 1개 이상, 최대 6개까지 포함해야 합니다.")
     private List<String> query;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate endAt;
 }

--- a/backend/src/main/java/com/tamnara/backend/news/dto/response/AINewsResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/response/AINewsResponse.java
@@ -14,9 +14,9 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class AINewsResponse {
-    @Length(max = 24, message = "뉴스의 제목은 24자까지만 가능합니다.")
+//    @Length(max = 24, message = "뉴스의 제목은 24자까지만 가능합니다.")
     private String title;
-    @Length(max = 36, message = "뉴스의 미리보기 내용은 36자까지만 가능합니다.")
+//    @Length(max = 36, message = "뉴스의 미리보기 내용은 36자까지만 가능합니다.")
     private String summary;
     @Length(max = 255, message = "이미지 링크의 길이가 너무 깁니다.")
     private String imageUrl;

--- a/backend/src/main/java/com/tamnara/backend/news/dto/response/NewsDetailResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/response/NewsDetailResponse.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,7 +14,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class NewsDetailResponse {
-    @Length(max = 18, message = "타임라인 카드의 제목은 24자까지만 가능합니다.")
+//    @Length(max = 18, message = "타임라인 카드의 제목은 18자까지만 가능합니다.")
     private String title;
     @PastOrPresent(message = "날짜는 과거 또는 현재만 가능합니다.")
     private LocalDateTime updatedAt;

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -189,7 +189,7 @@ public class NewsServiceImpl implements NewsService {
         news.setIsHotissue(isHotissue);
         news.setRatioPosi(statistics.getPositive());
         news.setRatioNeut(statistics.getNeutral());
-        news.setRatioNeut(statistics.getNegative());
+        news.setRatioNega(statistics.getNegative());
         news.setUser(user);
         news.setCategory(category);
         newsRepository.save(news);

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -157,7 +157,16 @@ public class NewsServiceImpl implements NewsService {
 
         // 4. 저장
         // 4-1. 뉴스를 저장한다.
-        Optional<Category> category = categoryRepository.findByName(CategoryType.valueOf(aiNewsResponse.getCategory()));
+        Category category = null;
+        if (aiNewsResponse.getCategory() != null || !aiNewsResponse.getCategory().isEmpty()) {
+            try {
+                CategoryType categoryType = CategoryType.valueOf(aiNewsResponse.getCategory());
+                category = categoryRepository.findByName(categoryType)
+                        .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다."));
+            } catch (IllegalArgumentException e) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "올바르지 않은 카테고리 형식입니다.");
+            }
+        }
 
         News news = new News();
         news.setTitle(aiNewsResponse.getTitle());
@@ -167,7 +176,7 @@ public class NewsServiceImpl implements NewsService {
         news.setRatioNeut(statistics.getNeutral());
         news.setRatioNeut(statistics.getNegative());
         news.setUser(user);
-        news.setCategory(category.get());
+        news.setCategory(category);
         newsRepository.save(news);
 
         // 4-2. 타임라인 카드들을 저장한다.


### PR DESCRIPTION
## 연관된 이슈
#33 #34 #35

<br/>

## 작업 내용
#### BE-AI API 연동 이슈
  - [x] 뉴스 생성 컨트롤러(`createNews`)의 요청 DTO를 받는 방식을 @ModelAttribute -> @RequestBody으로 수정
  - [x] AI 연동 과정에서 `LocalDate` 타입 직렬화/역직렬화 처리
  - [x] AI 응답 구조에 맞춰 `WrappedDTO` 클래스 생성 및 응답 로직에 적용

#### 응답에 대한 예외 처리 이슈
  - [x] 길이 제한 예외 처리를 주석 처리하고, 응답의 문자열들을 길이 제한만큼만 저장하는 방식으로 임시 처리
  - [x] 뉴스 생성/업데이트 서비스 로직에 @Transactional 추가하여 원자성 보존

<br/>

## 추가 사항
- 길이 제한 관련 로직에 대해 추가 수정 필요
  - DB 컬럼의 길이 제한을 255로 연장
  - 응답을 길이 제한만큼 자르는 로직 제거