### PR TITLE
fix: DB 설정 및 AI URL 환경변수화, 문자열 길이 제한 완화 및 이미지 필드 처리 수정

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/config/WebClientConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package com.tamnara.backend.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -9,12 +10,10 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
 
-    private final String AI_BASE_URL = "http://35.216.120.155:8000/api";
-
     @Bean
-    public WebClient aiWebClient() {
+    public WebClient aiWebClient(@Value("${ai.base-url}") String aiBaseUrl) {
         return WebClient.builder()
-                .baseUrl(AI_BASE_URL)
+                .baseUrl(aiBaseUrl)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .build();
     }

--- a/backend/src/main/java/com/tamnara/backend/news/domain/News.java
+++ b/backend/src/main/java/com/tamnara/backend/news/domain/News.java
@@ -41,10 +41,10 @@ public class News {
     @OnDelete(action = OnDeleteAction.RESTRICT)
     private Category category;
 
-    @Column(name = "title", length = 24, nullable = false)
+    @Column(name = "title", length = 255, nullable = false)
     private String title;
 
-    @Column(name = "summary", length = 36, nullable = false)
+    @Column(name = "summary", length = 255, nullable = false)
     private String summary;
 
     @Column(name = "is_hotissue", nullable = false)

--- a/backend/src/main/java/com/tamnara/backend/news/domain/TimelineCard.java
+++ b/backend/src/main/java/com/tamnara/backend/news/domain/TimelineCard.java
@@ -26,7 +26,7 @@ public class TimelineCard {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private News news;
 
-    @Column(name = "title", length = 18, nullable = false)
+    @Column(name = "title", length = 255, nullable = false)
     private String title;
 
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)

--- a/backend/src/main/java/com/tamnara/backend/news/dto/response/AINewsResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/response/AINewsResponse.java
@@ -19,7 +19,7 @@ public class AINewsResponse {
 //    @Length(max = 36, message = "뉴스의 미리보기 내용은 36자까지만 가능합니다.")
     private String summary;
     @Length(max = 255, message = "이미지 링크의 길이가 너무 깁니다.")
-    private String imageUrl;
+    private String image;
     @ValueOfEnum(enumClass = CategoryType.class, message = "카테고리 값이 올바르지 않습니다.")
     private String category;
     @NotNull(message = "타임라인 카드는 비어 있을 수 없습니다.")

--- a/backend/src/main/java/com/tamnara/backend/news/dto/response/NewsDetailResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/response/NewsDetailResponse.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,6 +17,8 @@ import java.util.List;
 public class NewsDetailResponse {
 //    @Length(max = 18, message = "타임라인 카드의 제목은 18자까지만 가능합니다.")
     private String title;
+    @Length(max = 255, message = "이미지 링크의 길이가 너무 깁니다.")
+    private String image;
     @PastOrPresent(message = "날짜는 과거 또는 현재만 가능합니다.")
     private LocalDateTime updatedAt;
     private boolean bookmarked;

--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsImageRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsImageRepository.java
@@ -4,9 +4,7 @@ import com.tamnara.backend.news.domain.NewsImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
 public interface NewsImageRepository extends JpaRepository<NewsImage, Long> {
-    Optional<NewsImage> findByNewsId(Long newsId);
+    NewsImage findByNewsId(Long newsId);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -71,14 +71,10 @@ public class NewsServiceImpl implements NewsService {
 
     private final String TIMELINE_AI_ENDPOINT = "/timeline";
     private final String MERGE_AI_ENDPOINT = "/merge";
-    private final String HOTISSUE_AI_ENDPOINT = "/hot";
     private final String STATISTIC_AI_ENDPOINT = "/comment";
+    private final String HOTISSUE_AI_ENDPOINT = "/hot";
 
-    private final Integer NEWS_TITLE_LIMIT = 24;
-    private final Integer NEWS_SUMMARY_LIMIT = 36;
-    private final Integer TIMELINE_CARD_TITLE_LIMIT = 18;
-    private final Integer TAG_NAME_LIMIT = 10;
-    private final Integer STATISTICS_AI_SEARCH_CNT = 1;
+    private final Integer STATISTICS_AI_SEARCH_CNT = 10;
 
     @Override
     public List<NewsCardDTO> getHotissueNewsCardPage(Long userId) {
@@ -174,18 +170,8 @@ public class NewsServiceImpl implements NewsService {
         }
 
         News news = new News();
-        String title = aiNewsResponse.getTitle();
-        if (title != null && title.length() > NEWS_TITLE_LIMIT) {
-            title = title.substring(0, NEWS_TITLE_LIMIT);
-        }
-        news.setTitle(title);
-
-        String summary = aiNewsResponse.getSummary();
-        if (summary != null && summary.length() > NEWS_SUMMARY_LIMIT) {
-            summary = summary.substring(0, NEWS_SUMMARY_LIMIT);
-        }
-        news.setSummary(summary);
-
+        news.setTitle(aiNewsResponse.getTitle());
+        news.setSummary(aiNewsResponse.getSummary());
         news.setIsHotissue(isHotissue);
         news.setRatioPosi(statistics.getPositive());
         news.setRatioNeut(statistics.getNeutral());
@@ -201,10 +187,6 @@ public class NewsServiceImpl implements NewsService {
         req.getKeywords().forEach(keyword -> {
             NewsTag newsTag = new NewsTag();
             newsTag.setNews(news);
-
-            if (keyword != null && keyword.length() > TAG_NAME_LIMIT) {
-                keyword = keyword.substring(0, TAG_NAME_LIMIT);
-            }
 
             Optional<Tag> tag = tagRepository.findByName(keyword);
             if (tag.isPresent()) {
@@ -284,11 +266,7 @@ public class NewsServiceImpl implements NewsService {
 
         // 4. 저장
         // 4-1. 뉴스를 저장한다.
-        String summary = aiNewsResponse.getSummary();
-        if (summary != null && summary.length() > NEWS_SUMMARY_LIMIT) {
-            summary = summary.substring(0, NEWS_SUMMARY_LIMIT);
-        }
-        news.setSummary(summary);
+        news.setSummary(aiNewsResponse.getSummary());
 
         news.setUpdateCount(news.getUpdateCount() + 1);
         news.setRatioPosi(statistics.getPositive());
@@ -451,12 +429,7 @@ public class NewsServiceImpl implements NewsService {
     private void saveTimelineCards (List<TimelineCardDTO> timeline, LocalDate startAt, LocalDate endAt, News news) {
         for (TimelineCardDTO timelineCardDTO : timeline) {
             TimelineCard tc = new TimelineCard();
-
-            String title = timelineCardDTO.getTitle();
-            if (title != null && title.length() > TIMELINE_CARD_TITLE_LIMIT) {
-                title = title.substring(0, TIMELINE_CARD_TITLE_LIMIT);
-            }
-            tc.setTitle(title);
+            tc.setTitle(timelineCardDTO.getTitle());
 
             tc.setContent(timelineCardDTO.getContent());
             tc.setSource(timelineCardDTO.getSource());

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=backend
 
-spring.datasource.url=jdbc:mysql://localhost:3306/tamnara?serverTimezone=UTC&useSSL=false
-spring.datasource.username=root
-spring.datasource.password=
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update
@@ -18,3 +18,6 @@ kakao.client-id=${KAKAO_CLIENT_ID}
 kakao.redirect-uri=${KAKAO_REDIRECT_URI}
 
 jwt.secret=${JWT_SECRET_CODE}
+
+ai:
+  base-url=${AI_BASE_URL}

--- a/backend/src/test/java/com/tamnara/backend/news/RepositoryTest/NewsImageRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/RepositoryTest/NewsImageRepositoryTest.java
@@ -15,8 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -90,10 +88,10 @@ public class NewsImageRepositoryTest {
         em.clear();
 
         // when
-        Optional<NewsImage> findNewsImage = newsImageRepository.findByNewsId(news.getId());
+        NewsImage findNewsImage = newsImageRepository.findByNewsId(news.getId());
 
         // then
-        assertEquals(newsImage1.getNews().getId(), findNewsImage.get().getNews().getId());
+        assertEquals(newsImage1.getNews().getId(), findNewsImage.getNews().getId());
     }
 
     @Test


### PR DESCRIPTION
## 연관된 이슈
#37 #38 #39 

<br/>

## 작업 내용
- [x] DB 설정 및 AI API URL 환경변수화
- [x] 뉴스 및 타임라인 카드 도메인에서 문자열 길이 제한 완화
- [x] DTO에 누락된 이미지 필드 추가 및 뉴스 이미지가 존재하지 않을 경우의 예외 처리 문제 해결

<br/>

## 상세 내용
### DB 설정 및 AI API URL 환경변수화
`application.properties`, `/global/config/WebCilentConfig`
- DB
   - `DB_URL`
   -  `DB_USERNAME`
   - `DB_PASSWORD`
- AI
   - `AI_BASE_URL`

<br/>

### 뉴스 및 타임라인 카드 도메인에서 문자열 길이 제한 완화
`/news/domain/News`, `/news/domain/TimelineCard`
- News
   - `title`: 24 -> 255
   - `summary`: 36 -> 255 
- TimelineCard
   - `title`: 18 -> 255 

`/news/service/NewsServiceImpl`
- `substring()`으로 길이 제한만큼 자르는 로직 제거

<br/>

### DTO에 누락된 이미지 필드 추가 및 뉴스 이미지가 존재하지 않을 경우의 예외 처리 문제 해결
`/news/dto/response/NewsDetailResponse`
- 이미지 필드 추가: `image`

`/news/dto/response/AINewsResponse`
- 이미지 필드명 수정: `imageUrl` -> `image`

`/news/repository/NewsImageRepository`
- `findByNewsId()` 반환 타입 변경: `Optional<NewsImage>` -> `NewsImage`

`/news/service/NewsServiceImpl`
- 뉴스 생성 로직에 뉴스 이미지 저장 로직 추가
- 뉴스 업데이트 로직에 기존 뉴스 이미지 삭제 및 새로운 뉴스 이미지 저장 로직 추가
- 뉴스 이미지를 조회할 경우 이미지가 존재할 경우 URL을, 존재하지 않을 경우 null 반환 로직 추가