### PR TITLE
[풀스택] [fix] AI에 타임라인 병합 요청 시, 실패하거나 응답이 부적절하게 나오는 문제 해결

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/dto/request/AITimelineMergeRequest.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/request/AITimelineMergeRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class AITimelineMergeReqeust {
+public class AITimelineMergeRequest {
     @NotNull(message = "타임라인 카드는 비어 있을 수 없습니다.")
     @Size(min = 1, message = "최소 1개 이상의 카드가 포함되어야 합니다.")
     private List<TimelineCardDTO> timeline;

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -366,8 +366,6 @@ public class NewsServiceImpl implements NewsService {
     }
 
     private List<TimelineCardDTO> mergeTimelineCards(List<TimelineCardDTO> timeline) {
-        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt).reversed());
-
         // 1. 1일카드 -> 1주카드
         timeline = mergeAITimelineCards(timeline, TimelineCardType.DAY, 7);
 
@@ -382,7 +380,7 @@ public class NewsServiceImpl implements NewsService {
     }
 
     private List<TimelineCardDTO> mergeAITimelineCards(List<TimelineCardDTO> timeline, TimelineCardType duration, Integer countNum) {
-        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt).reversed());
+        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt));
 
         List<TimelineCardDTO> mergedList = new ArrayList<>();
         List<TimelineCardDTO> temp = new ArrayList<>();

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -365,7 +365,7 @@ public class NewsServiceImpl implements NewsService {
     }
 
     private List<TimelineCardDTO> mergeAITimelineCards(List<TimelineCardDTO> timeline) {
-        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt));
+        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt).reversed());
 
         // 1. 1일카드 -> 1주카드
         timeline = mergeTimelineCards(timeline, TimelineCardType.DAY, 7);
@@ -381,7 +381,7 @@ public class NewsServiceImpl implements NewsService {
     }
 
     private List<TimelineCardDTO> mergeTimelineCards(List<TimelineCardDTO> timeline, TimelineCardType duration, Integer countNum) {
-        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt));
+        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt).reversed());
 
         List<TimelineCardDTO> mergedList = new ArrayList<>();
         List<TimelineCardDTO> temp = new ArrayList<>();
@@ -417,7 +417,7 @@ public class NewsServiceImpl implements NewsService {
         temp.clear();
 
         timeline = mergedList;
-        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt));
+        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt).reversed());
 
         return timeline;
     }
@@ -453,7 +453,6 @@ public class NewsServiceImpl implements NewsService {
         for (TimelineCardDTO timelineCardDTO : timeline) {
             TimelineCard tc = new TimelineCard();
             tc.setTitle(timelineCardDTO.getTitle());
-
             tc.setContent(timelineCardDTO.getContent());
             tc.setSource(timelineCardDTO.getSource());
             tc.setDuration(TimelineCardType.valueOf(timelineCardDTO.getDuration()));


### PR DESCRIPTION
## 연관된 이슈 
#46 

<br/>

## 작업 내용
- [x] AI에 타임라인 카드 병합을 요청할 때, 타임라인 카드를 `startAt`을 기준으로 정렬한다.
- [x] 타임라인 카드 병합 요청 DTO의 이름 오타 수정: Reqeust -> Request
- [x] 타임라인 카드 병합용 헬퍼 메서드의 이름 서로 변경: : AI에게 요청을 보내는 메서드의 이름에 AI를 포함하고, 아닌 메서드에서 AI 제거
- [x] 타임라인 카드 정렬에 대한 주석에서 기준 변수에 대한 오타 수정: `endAt` -> `startAt`