### PR TITLE
[풀스택] [FIX] 뉴스 업데이트 시 여론 통계 저장 로직의 오타 수정, 뉴스 생성/업데이트/삭제 기준 숫자를 전역상수화

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -285,7 +285,7 @@ public class NewsServiceImpl implements NewsService {
 
         news.setUpdateCount(news.getUpdateCount() + 1);
         news.setRatioPosi(statistics.getPositive());
-        news.setRatioNeut(statistics.getNegative());
+        news.setRatioNeut(statistics.getNeutral());
         news.setRatioNega(statistics.getNegative());
         newsRepository.save(news);
 

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -75,7 +75,9 @@ public class NewsServiceImpl implements NewsService {
     private final String HOTISSUE_AI_ENDPOINT = "/hot";
 
     private final Integer STATISTICS_AI_SEARCH_CNT = 10;
-    private final Integer NEWS_DELETE_MONTHS = 3;
+    private final Integer NEWS_CREATE_DAYS = 30;
+    private final Integer NEWS_UPDATE_HOURS = 24;
+    private final Integer NEWS_DELETE_DAYS = 90;
 
     @Override
     public List<NewsCardDTO> getHotissueNewsCardPage(Long userId) {
@@ -153,7 +155,7 @@ public class NewsServiceImpl implements NewsService {
 
         // 1. AI에 요청하여 뉴스를 생성한다.
         LocalDate endAt = LocalDate.now();
-        LocalDate startAt = endAt.minusDays(7);
+        LocalDate startAt = endAt.minusDays(NEWS_CREATE_DAYS);
         AINewsResponse aiNewsResponse = createAINews(req.getKeywords(), startAt, endAt).getData();
 
         // 2. AI에 요청하여 타임라인 카드들을 병합한다.
@@ -241,7 +243,7 @@ public class NewsServiceImpl implements NewsService {
         News news = newsRepository.findById(newsId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."));
 
-        if (news.getUpdatedAt().isAfter(LocalDateTime.now().minusHours(24))) {
+        if (news.getUpdatedAt().isAfter(LocalDateTime.now().minusHours(NEWS_UPDATE_HOURS))) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "마지막 업데이트 이후 24시간이 지나지 않았습니다.");
         }
 
@@ -333,7 +335,7 @@ public class NewsServiceImpl implements NewsService {
         News news = newsRepository.findById(newsId)
             .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "요청하신 뉴스를 찾을 수 없습니다."));
 
-        if (news.getUpdatedAt().isAfter(LocalDateTime.now().minusMonths(NEWS_DELETE_MONTHS))) {
+        if (news.getUpdatedAt().isAfter(LocalDateTime.now().minusDays(NEWS_DELETE_DAYS))) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "마지막 업데이트 이후 3개월이 지나지 않았습니다.");
         }
 


### PR DESCRIPTION
## 연관된 이슈
#55 

<br/>

## 작업 내용
- [x] 뉴스 업데이트 시 여론 통계 저장 과정에서 중립에 부정을 저장하던 오타 수정
- [x] 뉴스 생성/업데이트/삭제 기준을 '시간'으로 통일 및 클래스 내부에서 전역변수로 상수화
- [x] 뉴스 생성/업데이트/삭제 상수에 운영용 숫자 적용

<br/>

## 상세 내용
- 뉴스 생성 시 기간 범위: 30일 전 ~ 오늘
- 뉴스 업데이트 불가 기간 범위: 마지막 업데이트일로부터 24시간 이내
- 뉴스 삭제 가능 기간: 마지막 업데이트일로부터 90일 이후