### PR TITLE
fix: '전체' 카테고리의 뉴스 카드 추가 로딩 로직 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
@@ -68,21 +68,24 @@ public class NewsController {
                 userId = userDetails.getUser().getId();
             }
 
-            if (category != null) {
+            if (offset > 0) {
                 // 추가 로딩
-                if (offset < 0) {
-                    throw new IllegalArgumentException();
-                }
-
                 int pageNum = offset / PAGE_SIZE;
                 int nextOffset = (pageNum + 1) * PAGE_SIZE;
 
-                List<NewsCardDTO> newsCards = newsService.getNormalNewsCardPage(userId, category, pageNum, PAGE_SIZE);
+                List<NewsCardDTO> newsCards;
+                boolean hasNext;
 
-                boolean hasNext = !newsService.getNormalNewsCardPage(userId, category, pageNum + 1, PAGE_SIZE).isEmpty();
+                if (category == "ALL") {
+                    newsCards = newsService.getNormalNewsCardPage(userId, pageNum, PAGE_SIZE);
+                    hasNext = !newsService.getNormalNewsCardPage(userId,pageNum + 1, PAGE_SIZE).isEmpty();
+                } else {
+                    newsCards = newsService.getNormalNewsCardPageByCategory(userId, category, pageNum, PAGE_SIZE);
+                    hasNext = !newsService.getNormalNewsCardPageByCategory(userId, category, pageNum + 1, PAGE_SIZE).isEmpty();
+                }
 
                 Map<String, Object> data = Map.of(
-                        category, newsCards,
+                        (category == null ? "ECT" : category), newsCards,
                         "offset", nextOffset,
                         "hasNext", hasNext
                 );
@@ -103,9 +106,9 @@ public class NewsController {
 
                     boolean hasNext;
                     if (Objects.equals(categoryName, "ALL")) {
-                        hasNext = newsService.getNormalNewsCardPage(null,1, PAGE_SIZE).isEmpty();
+                        hasNext = !newsService.getNormalNewsCardPage(null,1, PAGE_SIZE).isEmpty();
                     } else {
-                        hasNext = !newsService.getNormalNewsCardPage(null, categoryName, 1, PAGE_SIZE).isEmpty();
+                        hasNext = !newsService.getNormalNewsCardPageByCategory(null, categoryName, 1, PAGE_SIZE).isEmpty();
                     }
 
                     Map<String, Object> categoryNewsData = new HashMap<>();

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public interface NewsService {
     List<NewsCardDTO> getHotissueNewsCardPage(Long userId);
     List<NewsCardDTO> getNormalNewsCardPage(Long userId, Integer page, Integer size);
-    List<NewsCardDTO> getNormalNewsCardPage(Long userId, String category, Integer page, Integer size);
+    List<NewsCardDTO> getNormalNewsCardPageByCategory(Long userId, String category, Integer page, Integer size);
     Map<String, List<NewsCardDTO>> getNormalNewsCardPages(Long userId, Integer page, Integer size);
     NewsDetailResponse getNewsDetail(Long newsId, Long userId);
     NewsDetailResponse save(Long userId, boolean isHotissue, NewsCreateRequest req);

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -92,11 +92,15 @@ public class NewsServiceImpl implements NewsService {
     }
 
     @Override
-    public List<NewsCardDTO> getNormalNewsCardPage(Long userId, String category, Integer page, Integer size) {
-        Category c = categoryRepository.findByName(CategoryType.valueOf(category.toUpperCase()))
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."));
-
-        Page<News> newsPage = newsRepository.findByIsHotissueFalseAndCategoryId(c.getId(), PageRequest.of(page, size));
+    public List<NewsCardDTO> getNormalNewsCardPageByCategory(Long userId, String category, Integer page, Integer size) {
+        Page<News> newsPage;
+        if (category != null) {
+            Category c = categoryRepository.findByName(CategoryType.valueOf(category.toUpperCase()))
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."));
+            newsPage = newsRepository.findByIsHotissueFalseAndCategoryId(c.getId(), PageRequest.of(page, size));
+        } else {
+            newsPage = newsRepository.findByIsHotissueFalseAndCategoryId(null, PageRequest.of(page, size));
+        }
         return getNewsCardDTOList(userId, newsPage);
     }
 

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -87,7 +87,7 @@ public class NewsServiceImpl implements NewsService {
 
     @Override
     public List<NewsCardDTO> getNormalNewsCardPage(Long userId, Integer page, Integer size) {
-        Page<News> newsPage = newsRepository.findAllByIsHotissueTrueOrderByIdAsc(Pageable.unpaged());
+        Page<News> newsPage = newsRepository.findByIsHotissueFalseOrderByUpdatedAtDescIdDesc(PageRequest.of(page, size));
         return getNewsCardDTOList(userId, newsPage);
     }
 


### PR DESCRIPTION
## 연관된 이슈
#57 

<br/>

## 작업 내용
- [x] 카테고리별 추가 로딩 로직에 '전체(ALL)' 카테고리의 뉴스 카드 추가 로딩 로직 추가
- [x] 카테고리별 추가 로딩 로직에 '기타(ECT, `null`)' 카테고리의 뉴스 카드 추가 로딩 로직 추가 
- [x] 뉴스 카드 초기 로딩 시, '전체' 카테고리의 hasNext 계산 로직 수정
- [x] `getNormalNewsCardPage()`의 오버로딩 메서드를 카테고리를 기준으로 이름 분리 -> `getNormalNewsCardPageByCategory()`

<br/>

## 상세 내용
- 카테고리별 추가 로딩 시, '전체(ALL)' 카테고리를 조회하고 싶은 경우 쿼리 파라미터 `category="ALL"`로 명시
- 카테고리별 추가 로딩 시, '기타(ECT)' 카테고리를 조회하고 싶은 경우 쿼리 파라미터 `category=null` 명시 또는 `category` 생략