### PR TITLE
fix: 이메일/닉네임 중복조회 CORS 허용

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
+import java.util.Locale;
 
 @Configuration
 @RequiredArgsConstructor
@@ -50,6 +51,8 @@ public class SecurityConfig {
                                         "/swagger-resources/**",
                                         "/webjars/**",
                                         "/auth/**",  // 로그인, 회원가입 등은 인증 없이 허용
+                                        "/users/check-email",
+                                        "/users/check-nickname",
                                         "/news/**"
                                 ).permitAll()
                                 .anyRequest().authenticated() // 나머지는 인증 필요

--- a/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
@@ -20,7 +20,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
-import java.util.Locale;
 
 @Configuration
 @RequiredArgsConstructor


### PR DESCRIPTION
이메일 중복조회, 닉네임 중복조회 엔드포인트를 permitAll()에 추가하여 API 사용이 가능하게 함.

관련 이슈
#67 