### PR TITLE
[풀스택] [fix] 뉴스 관련 로직 및 예외 처리 개선 및 타임라인 병합 조건 수정

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/exception/AIException.java
+++ b/backend/src/main/java/com/tamnara/backend/global/exception/AIException.java
@@ -1,0 +1,15 @@
+package com.tamnara.backend.global.exception;
+
+import com.tamnara.backend.news.dto.WrappedDTO;
+import lombok.Getter;
+
+@Getter
+public class AIException extends RuntimeException {
+    private final WrappedDTO<?> errorBody;
+
+    public AIException(WrappedDTO<?> errorBody) {
+        super("AI 처리 실패: " + errorBody.getMessage());
+        this.errorBody = errorBody;
+    }
+
+}

--- a/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
@@ -174,6 +174,10 @@ public class NewsController {
 
             Long userId = userDetails.getUser().getId();
             NewsDetailResponse res = newsService.save(userId, false, req);
+            if (res == null) {
+                return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+            }
+
             return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
                     "success", true,
                     "message", "데이터가 성공적으로 생성되었습니다.",
@@ -200,6 +204,10 @@ public class NewsController {
 
             Long userId = userDetails.getUser().getId();
             NewsDetailResponse res = newsService.update(newsId, userId);
+            if (res == null) {
+                return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+            }
+
             return ResponseEntity.status(HttpStatus.OK).body(Map.of(
                     "success", true,
                     "message", "데이터가 성공적으로 업데이트되었습니다.",

--- a/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
@@ -231,11 +231,7 @@ public class NewsController {
             Long resNewsId = newsService.delete(newsId, userDetails.getUser().getId());
 
             Map<String, Object> data = Map.of("newsId", resNewsId);
-            return ResponseEntity.status(HttpStatus.NO_CONTENT).body(Map.of(
-                    "success", true,
-                    "message", "데이터가 성공적으로 삭제되었습니다.",
-                    "data", data
-            ));
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {

--- a/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
@@ -236,9 +236,7 @@ public class NewsController {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN, "뉴스를 삭제할 권한이 없습니다.");
             }
 
-            Long resNewsId = newsService.delete(newsId, userDetails.getUser().getId());
-
-            Map<String, Object> data = Map.of("newsId", resNewsId);
+            newsService.delete(newsId, userDetails.getUser().getId());
             return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());

--- a/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
@@ -228,7 +228,7 @@ public class NewsController {
                 throw new ResponseStatusException(HttpStatus.FORBIDDEN, "뉴스를 삭제할 권한이 없습니다.");
             }
 
-            Long resNewsId = newsService.delete(newsId, null);
+            Long resNewsId = newsService.delete(newsId, userDetails.getUser().getId());
 
             Map<String, Object> data = Map.of("newsId", resNewsId);
             return ResponseEntity.status(HttpStatus.NO_CONTENT).body(Map.of(

--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsImageRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsImageRepository.java
@@ -4,7 +4,9 @@ import com.tamnara.backend.news.domain.NewsImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface NewsImageRepository extends JpaRepository<NewsImage, Long> {
-    NewsImage findByNewsId(Long newsId);
+    Optional<NewsImage> findByNewsId(Long newsId);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
@@ -15,5 +15,5 @@ public interface NewsService {
     NewsDetailResponse getNewsDetail(Long newsId, Long userId);
     NewsDetailResponse save(Long userId, boolean isHotissue, NewsCreateRequest req);
     NewsDetailResponse update(Long newsId, Long userId);
-    Long delete(Long newsId, Long userId);
+    void delete(Long newsId, Long userId);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -248,7 +248,7 @@ public class NewsServiceImpl implements NewsService {
 
         // 1. 뉴스, 타임라인 카드들, 뉴스태그들을 찾는다.
         News news = newsRepository.findById(newsId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "요청하신 뉴스를 찾을 수 없습니다."));
 
         if (news.getUpdatedAt().isAfter(LocalDateTime.now().minusHours(NEWS_UPDATE_HOURS))) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "마지막 업데이트 이후 24시간이 지나지 않았습니다.");

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -342,7 +342,7 @@ public class NewsServiceImpl implements NewsService {
     }
 
     @Override
-    public Long delete(Long newsId, Long userId) {
+    public void delete(Long newsId, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
 
@@ -358,7 +358,6 @@ public class NewsServiceImpl implements NewsService {
         }
 
         newsRepository.delete(news);
-        return newsId;
     }
 
 

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -135,8 +135,8 @@ public class NewsServiceImpl implements NewsService {
 
         List<TimelineCardDTO> timelineCardDTOList = getTimelineCardDTOList(news);
 
-        NewsImage newsImage = newsImageRepository.findByNewsId(news.getId());
-        String image = (newsImage != null) ? newsImage.getUrl() : null;
+        Optional<NewsImage> newsImage = newsImageRepository.findByNewsId(news.getId());
+        String image = newsImage.map(NewsImage::getUrl).orElse(null);
 
         StatisticsDTO statistics = getStatisticsDTO(news);
         boolean bookmarked = user.map(u -> getBookmarked(u, news)).orElse(false);
@@ -301,9 +301,9 @@ public class NewsServiceImpl implements NewsService {
         saveTimelineCards(newTimeline, news);
 
         // 4-3. 기존 뉴스 이미지를 삭제하고 새로운 뉴스 이미지를 저장한다.
-        if (newsImageRepository.findByNewsId(news.getId()) != null) {
-            NewsImage oldNewsImage = newsImageRepository.findByNewsId(news.getId());
-            newsImageRepository.delete(oldNewsImage);
+        if (newsImageRepository.findByNewsId(news.getId()).isPresent()) {
+            Optional<NewsImage> oldNewsImage = newsImageRepository.findByNewsId(news.getId());
+            newsImageRepository.delete(oldNewsImage.get());
         }
         NewsImage updatedNewsImage = new NewsImage();
         updatedNewsImage.setNews(news);
@@ -483,8 +483,8 @@ public class NewsServiceImpl implements NewsService {
         List<NewsCardDTO> newsCardDTOList = new ArrayList<>();
 
         newsPage.forEach(news -> {
-            NewsImage newsImage = newsImageRepository.findByNewsId(news.getId());
-            String image = (newsImage != null) ? newsImage.getUrl() : null;
+            Optional<NewsImage> newsImage = newsImageRepository.findByNewsId(news.getId());
+            String image = newsImage.map(NewsImage::getUrl).orElse(null);
 
             String categoryName = news.getCategory() != null ? news.getCategory().getName().toString() : null;
 

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -141,6 +141,9 @@ public class NewsServiceImpl implements NewsService {
         StatisticsDTO statistics = getStatisticsDTO(news);
         boolean bookmarked = user.map(u -> getBookmarked(u, news)).orElse(false);
 
+        news.setViewCount(news.getViewCount() + 1);
+        newsRepository.save(news);
+
         return new NewsDetailResponse(
                 news.getTitle(),
                 image,

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -96,7 +96,7 @@ public class NewsServiceImpl implements NewsService {
         Page<News> newsPage;
         if (category != null) {
             Category c = categoryRepository.findByName(CategoryType.valueOf(category.toUpperCase()))
-                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."));
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다."));
             newsPage = newsRepository.findByIsHotissueFalseAndCategoryId(c.getId(), PageRequest.of(page, size));
         } else {
             newsPage = newsRepository.findByIsHotissueFalseAndCategoryId(null, PageRequest.of(page, size));

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.tamnara.backend.bookmark.domain.Bookmark;
 import com.tamnara.backend.bookmark.repository.BookmarkRepository;
+import com.tamnara.backend.global.exception.AIException;
 import com.tamnara.backend.news.domain.Category;
 import com.tamnara.backend.news.domain.CategoryType;
 import com.tamnara.backend.news.domain.News;
@@ -38,10 +39,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -370,6 +373,12 @@ public class NewsServiceImpl implements NewsService {
                 .uri(TIMELINE_AI_ENDPOINT)
                 .bodyValue(aiNewsRequest)
                 .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        clientResponse -> clientResponse
+                                .bodyToMono(new ParameterizedTypeReference<WrappedDTO<AINewsResponse>>() {})
+                                .flatMap(errorBody -> Mono.error(new AIException(errorBody)))
+                )
                 .bodyToMono(new ParameterizedTypeReference<WrappedDTO<AINewsResponse>>() {})
                 .block();
     }
@@ -412,6 +421,12 @@ public class NewsServiceImpl implements NewsService {
                         .uri(MERGE_AI_ENDPOINT)
                         .bodyValue(mergeRequest)
                         .retrieve()
+                        .onStatus(
+                                HttpStatusCode::isError,
+                                clientResponse -> clientResponse
+                                        .bodyToMono(new ParameterizedTypeReference<WrappedDTO<TimelineCardDTO>>() {})
+                                        .flatMap(errorBody -> Mono.error(new AIException(errorBody)))
+                        )
                         .bodyToMono(new ParameterizedTypeReference<WrappedDTO<TimelineCardDTO>>() {})
                         .block();
 
@@ -441,6 +456,12 @@ public class NewsServiceImpl implements NewsService {
                 .uri(STATISTIC_AI_ENDPOINT)
                 .bodyValue(aiStatisticsRequest)
                 .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        clientResponse -> clientResponse
+                                .bodyToMono(new ParameterizedTypeReference<WrappedDTO<StatisticsDTO>>() {})
+                                .flatMap(errorBody -> Mono.error(new AIException(errorBody)))
+                )
                 .bodyToMono(new ParameterizedTypeReference<WrappedDTO<StatisticsDTO>>() {})
                 .block();
     }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -392,7 +392,7 @@ public class NewsServiceImpl implements NewsService {
 
         // 3. 1달카드: 3개월 지남 -> 삭제
         timeline.removeIf(tc -> (TimelineCardType.valueOf(tc.getDuration()) == TimelineCardType.MONTH)
-                && (tc.getStartAt().isAfter(LocalDate.now().minusMonths(3))));
+                && (tc.getStartAt().isBefore(LocalDate.now().minusMonths(3))));
 
         return timeline;
     }


### PR DESCRIPTION
## 연관된 이슈
#70 #75 #91 #92

<br/>

## 작업 내용
- [x] AI API의 4xx, 5xx 응답에 대한 예외 처리
- [x] 뉴스 이미지 조회 리포지토리 메서드의 반환 타입에 `Optional<T>` 래핑 적용 및 서비스 로직 정리
- [x] 뉴스 삭제 컨트롤러의 응답 및 서비스 로직 정리
- [x] 타임라인 병합 과정에서 1달카드 삭제 조건읠 '3개월 이내'에서 '3개월 이전'으로 변경하여 버그 해결
- 기타
   - [x] 뉴스 단건 조회 시 조회수 증가 처리 로직 추가 
   - [x] 존재하지 않는 카테고리 조회 시 `400 Bad Request` 응답을 반환하도록 Http Status 변경
   - [x] 뉴스 업데이트 요청을 받았을 때, 업데이트 대상인 뉴스가 존재하지 않는 경우의 예외 메시지를 명시적으로 변경('뉴스' 키워드 삽입)
   - [x] 뉴스 삭제 컨트롤러에서 뉴스 삭제 서비스를 호출할 때 누락된 `userId` 매개변수 추가

<br/>

## 상세 내용
### AI API 예외 처리
- AI API 요청 시 4xx 또는 5xx 응답이 반환될 경우 AIException으로 래핑하여 통일된 예외 구조 유지
- AI API가 반환한 `message` 필드를 예외 메시지로 사용하여 디버깅 용이성 증가
- WebClient의 `.onStatus()`를 통해 예외 body를 파싱하여 처리
- 타임라인 생성 외부 API에서 `404 Not Found` 응답이 오는 경우, `204 No Content`를 반환하여 사용자 기능 흐름이 중단되지 않도록 개선

<br/>

### 뉴스 이미지 조회 로직 개선
- 뉴스 이미지 조회 리포지토리 메서드 `findByNewsId()`의 반환 타입에 `Optional<T>` 적용하여 NPE 방지 및 후속 로직에서 명시적으로 처리
- 리포지토리 메서드의 변경 내용을 서비스 로직에 적용하여 정리
```java
Optional<NewsImage> newsImage = newsImageRepository.findByNewsId(news.getId());
String image = newsImage.map(NewsImage::getUrl).orElse(null);
```
- 이외 뉴스 기능, 댓글 기능, 북마크 기능에서 단건 조회 메서드의 반환 타입에 `Optional<T>`이 적용된 상태 확인

<br/>

### 뉴스 삭제 응답 및 서비스 로직 정리
- 삭제 성공 시 `204 No Content`에 맞게 응답 body 제거
- 서비스에서 삭제된 뉴스 ID를 반환하던 불필요한 로직 제거

<br/>

###  타임라인 병합 시 버그 수정
- 문제: 1달 카드가 생성되는 즉시 삭제되어 생성된 뉴스에 타임라인 카드가 존재하지 않거나 부족한 경우 발생
- 해결: 1달 카드 삭제 조건을 "3개월 이내"에서 "3개월 이전"으로 변경하여 기존 삭제 조건 오류 수정
```java
timeline.removeIf(tc -> (TimelineCardType.valueOf(tc.getDuration()) == TimelineCardType.MONTH)
        && (tc.getStartAt().isBefore(LocalDate.now().minusMonths(3))));
```