### PR TITLE
[풀스택] [refactor] 댓글 삭제 응답 및 서비스 로직 정리

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/controller/CommentController.java
@@ -106,17 +106,8 @@ public class CommentController {
             }
 
             Long userId = userDetails.getUser().getId();
-            Long deletedCommentId = commentService.delete(userId, newsId, commentId);
-
-            Map<String, Object> data = Map.of(
-                    "commendId", deletedCommentId
-            );
-
-            return ResponseEntity.status(HttpStatus.NO_CONTENT).body(Map.of(
-                    "success", true,
-                    "message", "댓글이 성공적으로 삭제되었습니다.",
-                    "data", data
-            ));
+            commentService.delete(userId, newsId, commentId);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {

--- a/backend/src/main/java/com/tamnara/backend/comment/service/CommentService.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/service/CommentService.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface CommentService {
     List<CommentDTO> getComments(Long newsId, Integer page, Integer size);
     Long save(Long userId, Long newsId, CommentCreateRequest commentCreateRequest);
-    Long delete(Long userId, Long newsId, Long commentId);
+    void delete(Long userId, Long newsId, Long commentId);
 }

--- a/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
@@ -66,7 +66,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public Long delete(Long userId, Long newsId, Long commentId) {
+    public void delete(Long userId, Long newsId, Long commentId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
 
@@ -81,6 +81,5 @@ public class CommentServiceImpl implements CommentService {
         } else {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "댓글을 삭제할 권한이 없습니다.");
         }
-        return commentId;
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#91 

<br/>

## 작업 내용
- [x] 댓글 삭제 컨트롤러의 응답 및 서비스 로직 정리

<br/>

## 상세 내용
### 댓글 삭제 응답 및 서비스 로직 정리
- 삭제 성공 시 `204 No Content`에 맞게 응답 body 제거
- 서비스에서 삭제된 댓글 ID를 반환하던 불필요한 로직 제거
