### PR TITLE
[풀스택] [refactor] 뉴스 생성/업데이트 로직에서 여론 통계 생성 API 요청을 비동기 처리

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/BackendApplication.java
+++ b/backend/src/main/java/com/tamnara/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package com.tamnara.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/tamnara/backend/global/exception/AIException.java
+++ b/backend/src/main/java/com/tamnara/backend/global/exception/AIException.java
@@ -2,13 +2,16 @@ package com.tamnara.backend.global.exception;
 
 import com.tamnara.backend.news.dto.WrappedDTO;
 import lombok.Getter;
+import org.springframework.http.HttpStatusCode;
 
 @Getter
 public class AIException extends RuntimeException {
     private final WrappedDTO<?> errorBody;
+    private final HttpStatusCode status;
 
-    public AIException(WrappedDTO<?> errorBody) {
+    public AIException(HttpStatusCode status, WrappedDTO<?> errorBody) {
         super("AI 처리 실패: " + errorBody.getMessage());
+        this.status = status;
         this.errorBody = errorBody;
     }
 

--- a/backend/src/main/java/com/tamnara/backend/news/service/AsyncAIService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/AsyncAIService.java
@@ -1,0 +1,11 @@
+package com.tamnara.backend.news.service;
+
+import com.tamnara.backend.news.dto.StatisticsDTO;
+import com.tamnara.backend.news.dto.WrappedDTO;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface AsyncAIService {
+    CompletableFuture<WrappedDTO<StatisticsDTO>> getAIStatisticsDTO(String endpoint, List<String> keywords, Integer num);
+}

--- a/backend/src/main/java/com/tamnara/backend/news/service/AsyncAIService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/AsyncAIService.java
@@ -7,5 +7,5 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public interface AsyncAIService {
-    CompletableFuture<WrappedDTO<StatisticsDTO>> getAIStatisticsDTO(String endpoint, List<String> keywords, Integer num);
+    CompletableFuture<WrappedDTO<StatisticsDTO>> getAIStatistics(String endpoint, List<String> keywords, Integer num);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/AsyncAIServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/AsyncAIServiceImpl.java
@@ -1,0 +1,51 @@
+package com.tamnara.backend.news.service;
+
+import com.tamnara.backend.global.exception.AIException;
+import com.tamnara.backend.news.dto.StatisticsDTO;
+import com.tamnara.backend.news.dto.WrappedDTO;
+import com.tamnara.backend.news.dto.request.AIStatisticsRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+public class AsyncAIServiceImpl implements AsyncAIService {
+
+    private final WebClient aiWebClient;
+
+    @Async
+    public CompletableFuture<WrappedDTO<StatisticsDTO>> getAIStatisticsDTO(String endpoint, List<String> keywords, Integer num) {
+        AIStatisticsRequest req = new AIStatisticsRequest(
+                keywords,
+                num
+        );
+
+        WrappedDTO<StatisticsDTO> res = aiWebClient.post()
+                .uri(endpoint)
+                .bodyValue(req)
+                .retrieve()
+                .onStatus(
+                        status -> status == HttpStatus.NOT_FOUND,
+                        clientResponse -> Mono.empty()
+                )
+                .onStatus(
+                        HttpStatusCode::isError,
+                        clientResponse -> clientResponse
+                                .bodyToMono(new ParameterizedTypeReference<WrappedDTO<StatisticsDTO>>() {})
+                                .flatMap(errorBody -> Mono.error(new AIException(errorBody)))
+                )
+                .bodyToMono(new ParameterizedTypeReference<WrappedDTO<StatisticsDTO>>() {})
+                .block();
+
+        return CompletableFuture.completedFuture(res);
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/news/service/AsyncAIServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/AsyncAIServiceImpl.java
@@ -23,7 +23,7 @@ public class AsyncAIServiceImpl implements AsyncAIService {
     private final WebClient aiWebClient;
 
     @Async
-    public CompletableFuture<WrappedDTO<StatisticsDTO>> getAIStatisticsDTO(String endpoint, List<String> keywords, Integer num) {
+    public CompletableFuture<WrappedDTO<StatisticsDTO>> getAIStatistics(String endpoint, List<String> keywords, Integer num) {
         AIStatisticsRequest req = new AIStatisticsRequest(
                 keywords,
                 num

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -19,7 +19,6 @@ import com.tamnara.backend.news.dto.StatisticsDTO;
 import com.tamnara.backend.news.dto.TimelineCardDTO;
 import com.tamnara.backend.news.dto.WrappedDTO;
 import com.tamnara.backend.news.dto.request.AINewsRequest;
-import com.tamnara.backend.news.dto.request.AIStatisticsRequest;
 import com.tamnara.backend.news.dto.request.AITimelineMergeRequest;
 import com.tamnara.backend.news.dto.request.NewsCreateRequest;
 import com.tamnara.backend.news.dto.response.AINewsResponse;
@@ -55,12 +54,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
 public class NewsServiceImpl implements NewsService {
 
     private final WebClient aiWebClient;
+    private final AsyncAIService asyncAiService;
 
     private final NewsRepository newsRepository;
     private final TimelineCardRepository timelineCardRepository;
@@ -163,6 +164,9 @@ public class NewsServiceImpl implements NewsService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
 
+        // 0. 뉴스의 여론 통계 생성을 비동기적으로 시작한다.
+        CompletableFuture<WrappedDTO<StatisticsDTO>> statsAsync = asyncAiService.getAIStatisticsDTO(STATISTIC_AI_ENDPOINT, req.getKeywords(), STATISTICS_AI_SEARCH_CNT);
+
         // 1. AI에 요청하여 뉴스를 생성한다.
         LocalDate endAt = LocalDate.now();
         LocalDate startAt = endAt.minusDays(NEWS_CREATE_DAYS);
@@ -175,8 +179,9 @@ public class NewsServiceImpl implements NewsService {
         // 2. AI에 요청하여 타임라인 카드들을 병합한다.
         List<TimelineCardDTO> timeline = mergeTimelineCards(aiNewsResponse.getTimeline());
 
-        // 3. AI에 요청하여 뉴스의 여론 통계를 생성한다.
-        StatisticsDTO statistics = getAIStatisticsDTO(req.getKeywords(), STATISTICS_AI_SEARCH_CNT).getData();
+        // 3. 뉴스의 여론 통계 생성 응답을 기다린다.
+        WrappedDTO<StatisticsDTO> resStats = statsAsync.join();
+        StatisticsDTO statistics = (resStats != null && resStats.getData() != null) ? statsAsync.join().getData() : null;
 
         // 4. 저장
         // 4-1. 뉴스를 저장한다.
@@ -195,9 +200,11 @@ public class NewsServiceImpl implements NewsService {
         news.setTitle(aiNewsResponse.getTitle());
         news.setSummary(aiNewsResponse.getSummary());
         news.setIsHotissue(isHotissue);
-        news.setRatioPosi(statistics.getPositive());
-        news.setRatioNeut(statistics.getNeutral());
-        news.setRatioNega(statistics.getNegative());
+        if (statistics != null) {
+            news.setRatioPosi(statistics.getPositive());
+            news.setRatioNeut(statistics.getNeutral());
+            news.setRatioNega(statistics.getNegative());
+        }
         news.setUser(user);
         news.setCategory(category);
         newsRepository.save(news);
@@ -281,7 +288,10 @@ public class NewsServiceImpl implements NewsService {
             keywords.add(tag.getTag().getName());
         }
 
-        // 2. AI에게 요청하여 가장 최신 타임라인 카드의 endAt 이후 시점에 대한 뉴스를 생성한다.
+        // 2-1. 뉴스의 여론 통계 생성을 비동기적으로 시작한다.
+        CompletableFuture<WrappedDTO<StatisticsDTO>> statsAsync = asyncAiService.getAIStatisticsDTO(STATISTIC_AI_ENDPOINT, keywords, STATISTICS_AI_SEARCH_CNT);
+
+        // 3. AI에게 요청하여 가장 최신 타임라인 카드의 endAt 이후 시점에 대한 뉴스를 생성한다.
         LocalDate startAt = timelineCards.getFirst().getEndAt();
         LocalDate endAt = LocalDate.now();
         WrappedDTO<AINewsResponse> res = createAINews(keywords, startAt, endAt);
@@ -290,21 +300,24 @@ public class NewsServiceImpl implements NewsService {
         }
         AINewsResponse aiNewsResponse = res.getData();
 
-        // 3. 기존 타임라인 카드들과 합친 뒤, AI에게 요청하여 타임라인 카드들을 병합한다.
+        // 4. 기존 타임라인 카드들과 합친 뒤, AI에게 요청하여 타임라인 카드들을 병합한다.
         oldTimeline.addAll(aiNewsResponse.getTimeline());
         List<TimelineCardDTO> newTimeline = mergeTimelineCards(oldTimeline);
 
-        // 4. AI에 요청하여 뉴스의 여론 통계를 생성한다.
-        StatisticsDTO statistics = getAIStatisticsDTO(keywords, STATISTICS_AI_SEARCH_CNT).getData();
+        // 2-2. 뉴스의 여론 통계 생성 응답을 기다린다.
+        WrappedDTO<StatisticsDTO> resStats = statsAsync.join();
+        StatisticsDTO statistics = (resStats != null && resStats.getData() != null) ? statsAsync.join().getData() : null;
 
         // 4. 저장
         // 4-1. 뉴스를 저장한다.
         news.setSummary(aiNewsResponse.getSummary());
 
         news.setUpdateCount(news.getUpdateCount() + 1);
-        news.setRatioPosi(statistics.getPositive());
-        news.setRatioNeut(statistics.getNeutral());
-        news.setRatioNega(statistics.getNegative());
+        if (statistics != null) {
+            news.setRatioPosi(statistics.getPositive());
+            news.setRatioNeut(statistics.getNeutral());
+            news.setRatioNega(statistics.getNegative());
+        }
         newsRepository.save(news);
 
         // 4-2. 타임라인 카드들을 저장한다.
@@ -455,26 +468,6 @@ public class NewsServiceImpl implements NewsService {
         timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt).reversed());
 
         return timeline;
-    }
-
-    private WrappedDTO<StatisticsDTO> getAIStatisticsDTO(List<String> keywords, Integer num) {
-        AIStatisticsRequest aiStatisticsRequest = new AIStatisticsRequest(
-                keywords,
-                num
-        );
-
-        return aiWebClient.post()
-                .uri(STATISTIC_AI_ENDPOINT)
-                .bodyValue(aiStatisticsRequest)
-                .retrieve()
-                .onStatus(
-                        HttpStatusCode::isError,
-                        clientResponse -> clientResponse
-                                .bodyToMono(new ParameterizedTypeReference<WrappedDTO<StatisticsDTO>>() {})
-                                .flatMap(errorBody -> Mono.error(new AIException(errorBody)))
-                )
-                .bodyToMono(new ParameterizedTypeReference<WrappedDTO<StatisticsDTO>>() {})
-                .block();
     }
 
 

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 @Service
 @RequiredArgsConstructor
@@ -165,23 +166,36 @@ public class NewsServiceImpl implements NewsService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
 
         // 0. 뉴스의 여론 통계 생성을 비동기적으로 시작한다.
-        CompletableFuture<WrappedDTO<StatisticsDTO>> statsAsync = asyncAiService.getAIStatisticsDTO(STATISTIC_AI_ENDPOINT, req.getKeywords(), STATISTICS_AI_SEARCH_CNT);
+        CompletableFuture<WrappedDTO<StatisticsDTO>> statsAsync = asyncAiService
+                .getAIStatistics(STATISTIC_AI_ENDPOINT, req.getKeywords(), STATISTICS_AI_SEARCH_CNT)
+                .exceptionally(ex -> {
+                    Throwable cause = ex instanceof CompletionException ? ex.getCause() : ex;
+                    if (cause instanceof AIException aiEx && aiEx.getStatus() == HttpStatus.NOT_FOUND) {
+                        return null;
+                    }
+                    throw new CompletionException(cause);
+                });
 
         // 1. AI에 요청하여 뉴스를 생성한다.
-        LocalDate endAt = LocalDate.now();
-        LocalDate startAt = endAt.minusDays(NEWS_CREATE_DAYS);
-        WrappedDTO<AINewsResponse> res = createAINews(req.getKeywords(), startAt, endAt);
-        if (res == null || res.getData() == null) {
-            return null;
+        AINewsResponse aiNewsResponse;
+        try {
+            LocalDate endAt = LocalDate.now();
+            LocalDate startAt = endAt.minusDays(NEWS_CREATE_DAYS);
+            WrappedDTO<AINewsResponse> res = createAINews(req.getKeywords(), startAt, endAt);
+            aiNewsResponse = res.getData();
+        } catch (AIException ex) {
+            if (ex.getStatus() == HttpStatus.NOT_FOUND) {
+                return null;
+            }
+            throw ex;
         }
-        AINewsResponse aiNewsResponse = res.getData();
 
         // 2. AI에 요청하여 타임라인 카드들을 병합한다.
         List<TimelineCardDTO> timeline = mergeTimelineCards(aiNewsResponse.getTimeline());
 
         // 3. 뉴스의 여론 통계 생성 응답을 기다린다.
         WrappedDTO<StatisticsDTO> resStats = statsAsync.join();
-        StatisticsDTO statistics = (resStats != null && resStats.getData() != null) ? statsAsync.join().getData() : null;
+        StatisticsDTO statistics = (resStats != null && resStats.getData() != null) ? resStats.getData() : null;
 
         // 4. 저장
         // 4-1. 뉴스를 저장한다.
@@ -289,16 +303,21 @@ public class NewsServiceImpl implements NewsService {
         }
 
         // 2-1. 뉴스의 여론 통계 생성을 비동기적으로 시작한다.
-        CompletableFuture<WrappedDTO<StatisticsDTO>> statsAsync = asyncAiService.getAIStatisticsDTO(STATISTIC_AI_ENDPOINT, keywords, STATISTICS_AI_SEARCH_CNT);
+        CompletableFuture<WrappedDTO<StatisticsDTO>> statsAsync = asyncAiService.getAIStatistics(STATISTIC_AI_ENDPOINT, keywords, STATISTICS_AI_SEARCH_CNT);
 
         // 3. AI에게 요청하여 가장 최신 타임라인 카드의 endAt 이후 시점에 대한 뉴스를 생성한다.
-        LocalDate startAt = timelineCards.getFirst().getEndAt();
-        LocalDate endAt = LocalDate.now();
-        WrappedDTO<AINewsResponse> res = createAINews(keywords, startAt, endAt);
-        if (res == null || res.getData() == null) {
-            return null;
+        AINewsResponse aiNewsResponse;
+        try {
+            LocalDate startAt = timelineCards.getFirst().getEndAt().plusDays(1);
+            LocalDate endAt = LocalDate.now();
+            WrappedDTO<AINewsResponse> res = createAINews(keywords, startAt, endAt);
+            aiNewsResponse = res.getData();
+        } catch (AIException ex) {
+            if (ex.getStatus() == HttpStatus.NOT_FOUND) {
+                return null;
+            }
+            throw ex;
         }
-        AINewsResponse aiNewsResponse = res.getData();
 
         // 4. 기존 타임라인 카드들과 합친 뒤, AI에게 요청하여 타임라인 카드들을 병합한다.
         oldTimeline.addAll(aiNewsResponse.getTimeline());
@@ -306,7 +325,7 @@ public class NewsServiceImpl implements NewsService {
 
         // 2-2. 뉴스의 여론 통계 생성 응답을 기다린다.
         WrappedDTO<StatisticsDTO> resStats = statsAsync.join();
-        StatisticsDTO statistics = (resStats != null && resStats.getData() != null) ? statsAsync.join().getData() : null;
+        StatisticsDTO statistics = (resStats != null && resStats.getData() != null) ? resStats.getData() : null;
 
         // 4. 저장
         // 4-1. 뉴스를 저장한다.
@@ -394,14 +413,10 @@ public class NewsServiceImpl implements NewsService {
                 .bodyValue(aiNewsRequest)
                 .retrieve()
                 .onStatus(
-                        status -> status == HttpStatus.NOT_FOUND,
-                        clientResponse -> Mono.empty()
-                )
-                .onStatus(
                         HttpStatusCode::isError,
                         clientResponse -> clientResponse
                                 .bodyToMono(new ParameterizedTypeReference<WrappedDTO<AINewsResponse>>() {})
-                                .flatMap(errorBody -> Mono.error(new AIException(errorBody)))
+                                .flatMap(errorBody -> Mono.error(new AIException(clientResponse.statusCode(), errorBody)))
                 )
                 .bodyToMono(new ParameterizedTypeReference<WrappedDTO<AINewsResponse>>() {})
                 .block();
@@ -449,7 +464,7 @@ public class NewsServiceImpl implements NewsService {
                                 HttpStatusCode::isError,
                                 clientResponse -> clientResponse
                                         .bodyToMono(new ParameterizedTypeReference<WrappedDTO<TimelineCardDTO>>() {})
-                                        .flatMap(errorBody -> Mono.error(new AIException(errorBody)))
+                                        .flatMap(errorBody -> Mono.error(new AIException(clientResponse.statusCode(), errorBody)))
                         )
                         .bodyToMono(new ParameterizedTypeReference<WrappedDTO<TimelineCardDTO>>() {})
                         .block();


### PR DESCRIPTION
## 연관된 이슈
Closes #69 

<br/>

## 작업 내용
- [x] 메인 애플리케이션 클래스에 @EnableAsync 어노테이션을 적용
- [x] 비동기 처리용 AsyncAIService 클래스 생성
- [x] AsyncAIService 클래스에 여론 통계 생성 요청 API의 비동기 메서드 구현 및 NewsService에 있던 해당 헬퍼 메서드 제거
- [x] NewsService 클래스의 뉴스 생성/업데이트 로직에 AsyncAIService의 비동기 메서드 호출하여 비동기 처리

<br/>

## 상세 내용
### BackendApplication: 메인 애플리케이션 클래스
- @EnableAsync를 메인 애플리케이션 클래스에 적용하여 Spring 비동기 처리 기능을 활성화

<br/>

### AsyncAIService: 비동기 처리용 클래스 추가
- `/news/service/AsyncAIService`, `/news/service/AsyncAIServiceImpl`, 
- 기존 뉴스 생성/업데이트 로직에서 호출하던 여론 통계 생성 API 요청을 AsyncAIService를 통해 비동기로 분리
- AI API가 `404 Not Found` 응답을 반환할 경우 null로 반환되도록 처리

<br/>

### NewsService: 뉴스 생성/업데이트 로직 수정
- AsyncAIService의 여론 통계 생성 API 요청 메서드를 비동기로 호출
- API 요청 메서드의 응답이 null일 경우 여론 통계 저장 로직 생략
   - 뉴스 생성 시: 긍정, 중립, 부정을 모두 0으로 저장
   - 뉴스 업데이트 시: 기존 여론 통계 유지
- 모든 AI 관련 비동기 응답을 수신한 후 통합 저장이 진행되도록 조정하여 데이터의 원자성과 트랜잭션 일관성 유지

<br/>

## 성능 개선 효과
**조건:** 동일한 요청 키워드(SKT, 유심), 동일한 기간(30일)

- 동기적 처리 시 뉴스 생성 처리 시간
    1. 115235ms
    2. 141151ms
    3. 123482ms

- 비동기 처리 후 뉴스 생성 처리 시간
    1. 88457ms
    2. 99878ms
    3. 87038ms

**⇒ 개선된 속도: 약 38.34% 단축**