### PR TITLE
[풀스택] [refactor] 댓글 API 응답에 DTO 적용

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/controller/CommentController.java
@@ -1,8 +1,9 @@
 package com.tamnara.backend.comment.controller;
 
-import com.tamnara.backend.comment.dto.CommentCreateRequest;
 import com.tamnara.backend.comment.dto.CommentDTO;
-import com.tamnara.backend.comment.dto.CommentListResponse;
+import com.tamnara.backend.comment.dto.request.CommentCreateRequest;
+import com.tamnara.backend.comment.dto.response.CommentCreateResponse;
+import com.tamnara.backend.comment.dto.response.CommentListResponse;
 import com.tamnara.backend.comment.service.CommentService;
 import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.exception.CustomException;
@@ -22,7 +23,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -67,9 +67,9 @@ public class CommentController {
     }
 
     @PostMapping
-    public ResponseEntity<WrappedDTO<Map<String, Long>>> createComment(@PathVariable Long newsId,
-                                           @AuthenticationPrincipal UserDetailsImpl userDetails,
-                                           @RequestBody CommentCreateRequest req
+    public ResponseEntity<WrappedDTO<CommentCreateResponse>> createComment(@PathVariable Long newsId,
+                                                                           @AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                           @RequestBody CommentCreateRequest req
     ) {
         try {
             if (userDetails == null || userDetails.getUsername() == null) {
@@ -79,7 +79,7 @@ public class CommentController {
             Long userId = userDetails.getUser().getId();
             Long commentId = commentService.save(userId, newsId, req);
 
-            Map<String, Long> data = Map.of("commendId", commentId);
+            CommentCreateResponse data = new CommentCreateResponse(commentId);
 
             return ResponseEntity.status(HttpStatus.CREATED).body(
                     new WrappedDTO<> (

--- a/backend/src/main/java/com/tamnara/backend/comment/dto/CommentDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/dto/CommentDTO.java
@@ -9,10 +9,12 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public class CommentDTO {
-    Long id;
-    Long userId;
+    private Long id;
+    private Long userId;
+
     @Length(min = 1, message = "댓글란은 비어 있을 수 없습니다.")
     @Length(max = 150, message = "댓글 최대 길이를 초과하였습니다.")
-    String content;
-    LocalDateTime createdAt;
+    private String content;
+
+    private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/com/tamnara/backend/comment/dto/CommentListResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/dto/CommentListResponse.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CommentListResponse {
+    List<CommentDTO> comments;
+    int offset;
+    boolean hasNext;
+}

--- a/backend/src/main/java/com/tamnara/backend/comment/dto/request/CommentCreateRequest.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/dto/request/CommentCreateRequest.java
@@ -1,4 +1,4 @@
-package com.tamnara.backend.comment.dto;
+package com.tamnara.backend.comment.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/src/main/java/com/tamnara/backend/comment/dto/response/CommentCreateResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/dto/response/CommentCreateResponse.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class CommentCreateResponse {
-    Long commentId;
+    private Long commentId;
 }

--- a/backend/src/main/java/com/tamnara/backend/comment/dto/response/CommentCreateResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/dto/response/CommentCreateResponse.java
@@ -1,0 +1,10 @@
+package com.tamnara.backend.comment.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentCreateResponse {
+    Long commentId;
+}

--- a/backend/src/main/java/com/tamnara/backend/comment/dto/response/CommentListResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/dto/response/CommentListResponse.java
@@ -1,5 +1,6 @@
-package com.tamnara.backend.comment.dto;
+package com.tamnara.backend.comment.dto.response;
 
+import com.tamnara.backend.comment.dto.CommentDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/backend/src/main/java/com/tamnara/backend/comment/dto/response/CommentListResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/dto/response/CommentListResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 public class CommentListResponse {
-    List<CommentDTO> comments;
-    int offset;
-    boolean hasNext;
+    private List<CommentDTO> comments;
+    private int offset;
+    private boolean hasNext;
 }

--- a/backend/src/main/java/com/tamnara/backend/comment/service/CommentService.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/service/CommentService.java
@@ -1,6 +1,6 @@
 package com.tamnara.backend.comment.service;
 
-import com.tamnara.backend.comment.dto.CommentCreateRequest;
+import com.tamnara.backend.comment.dto.request.CommentCreateRequest;
 import com.tamnara.backend.comment.dto.CommentDTO;
 
 import java.util.List;

--- a/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
@@ -1,7 +1,7 @@
 package com.tamnara.backend.comment.service;
 
 import com.tamnara.backend.comment.domain.Comment;
-import com.tamnara.backend.comment.dto.CommentCreateRequest;
+import com.tamnara.backend.comment.dto.request.CommentCreateRequest;
 import com.tamnara.backend.comment.dto.CommentDTO;
 import com.tamnara.backend.comment.repository.CommentRepository;
 import com.tamnara.backend.news.domain.News;

--- a/backend/src/main/java/com/tamnara/backend/global/dto/WrappedDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/global/dto/WrappedDTO.java
@@ -1,0 +1,17 @@
+package com.tamnara.backend.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WrappedDTO<T> {
+    private boolean success;
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+}

--- a/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.tamnara.backend.global.exception;
 
+import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.response.ErrorResponse;
 import com.tamnara.backend.user.exception.DuplicateUsernameException;
 import com.tamnara.backend.user.exception.DuplicateEmailException;
@@ -14,11 +15,14 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<?> handleCustomException(CustomException e) {
-        return ResponseEntity.status(e.getStatus()).body(Map.of(
-                "success", false,
-                "message", e.getMessage()
-        ));
+    public ResponseEntity<WrappedDTO<Void>> handleCustomException(CustomException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(new WrappedDTO<>(
+                        false,
+                        e.getMessage(),
+                        null
+                ));
     }
 
     @ExceptionHandler(DuplicateUsernameException.class)

--- a/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
@@ -16,9 +16,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<WrappedDTO<Void>> handleCustomException(CustomException e) {
-        return ResponseEntity
-                .status(e.getStatus())
-                .body(new WrappedDTO<>(
+        return ResponseEntity.status(e.getStatus()).body(
+                new WrappedDTO<>(
                         false,
                         e.getMessage(),
                         null


### PR DESCRIPTION
## 연관된 이슈
Closes #98

<br/>

## 작업 내용
- [x] chore: 공통 응답 DTO `WrappedDTO`를 global.dto 패키지에 추가한다.
- [x] 에러 발생 시 예외를 처리하는 custom exception 핸들러의 응답 바디에 `WrappedDTO`를 적용한다.
- [x] `WrappedDTO<T>`에서 data 필드의 타입 T가 될 응답 DTO를 추가한다.
- [x] 댓글 기능 컨트롤러의 응답 `WrappedDTO<ResponseDTO>`를 적용한다.

<br/>

## 상세 내용
### DTO 추가
- `WrappedDTO<T>`: 공통 응답 구조 DTO로, T는 데이터 필드의 타입을 의미
- `CommentListResponse`: 댓글 목록 응답 DTO
- `CommentCreateResponse`: 댓글 생성 응답 DTO

### 응답에 DTO 적용
- 댓글 목록 조회: `ResponseEntity<WrappedDTO<CommentListResponse>>` - `200 Ok`
- 댓글 생성: `ResponseEntity<WrappedDTO<CommentCreateResponse>>` - `201 Created`
- 댓글 삭제: `ResponseEntity<WrappedDTO<Void>>` - `204 No Content`

### 응답 테스트
#### 성공
```json
{
  "success": true,
  "message": "댓글이 성공적으로 생성되었습니다.",
  "data": {
    "commentId": 49
  }
}
```

#### 실패
```json
{
  "success": false,
  "message": "인증되지 않은 사용자입니다."
}
```

### 확인사항
- [x] 컨트롤러에 `<Map>`, `Map.of()`가 존재하지 않는다.
- [x] 서비스에 `<Map>`, `Map.of()`가 존재하지 않는다.