### PR TITLE
[풀스택] [refactor] 북마크 API 응답에 DTO 적용

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
@@ -1,6 +1,7 @@
 package com.tamnara.backend.bookmark.controller;
 
 import com.tamnara.backend.bookmark.service.BookmarkService;
+import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.exception.CustomException;
 import com.tamnara.backend.user.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class BookmarkController {
     private final BookmarkService bookmarkService;
 
     @PostMapping
-    public ResponseEntity<?> addBookmark(@PathVariable Long newsId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<WrappedDTO<Map<String, Long>>> addBookmark(@PathVariable Long newsId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
             if (userDetails == null || userDetails.getUser() == null) {
                 throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인된 사용자가 아닙니다.");
@@ -33,13 +34,14 @@ public class BookmarkController {
             Long userId = userDetails.getUser().getId();
             Long bookmarkId = bookmarkService.addBookmark(userId, newsId);
 
-            Map<String, Object> data = Map.of("bookmarkId", bookmarkId);
+            Map<String, Long> data = Map.of("bookmarkId", bookmarkId);
 
-            return ResponseEntity.ok(Map.of(
-                    "success", true,
-                    "message", "북마크가 성공적으로 추가되었습니다.",
-                    "data", data
-            ));
+            return ResponseEntity.status(HttpStatus.OK).body(
+                    new WrappedDTO<>(
+                            true,
+                            "북마크가 성공적으로 추가되었습니다.",
+                            data
+                    ));
 
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
@@ -52,7 +54,7 @@ public class BookmarkController {
     }
 
     @DeleteMapping
-    public ResponseEntity<?> deleteBookmark(@PathVariable Long newsId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<Void> deleteBookmark(@PathVariable Long newsId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
             if (userDetails == null || userDetails.getUser() == null) {
                 throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인된 사용자가 아닙니다.");
@@ -60,8 +62,8 @@ public class BookmarkController {
 
             Long userId = userDetails.getUser().getId();
             bookmarkService.deleteBookmark(userId, newsId);
-            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {

--- a/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
@@ -1,5 +1,6 @@
 package com.tamnara.backend.bookmark.controller;
 
+import com.tamnara.backend.bookmark.dto.response.BookmarkAddResponse;
 import com.tamnara.backend.bookmark.service.BookmarkService;
 import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.exception.CustomException;
@@ -15,8 +16,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.Map;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/news/{newsId}/bookmark")
@@ -25,7 +24,7 @@ public class BookmarkController {
     private final BookmarkService bookmarkService;
 
     @PostMapping
-    public ResponseEntity<WrappedDTO<Map<String, Long>>> addBookmark(@PathVariable Long newsId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<WrappedDTO<BookmarkAddResponse>> addBookmark(@PathVariable Long newsId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
             if (userDetails == null || userDetails.getUser() == null) {
                 throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인된 사용자가 아닙니다.");
@@ -34,7 +33,7 @@ public class BookmarkController {
             Long userId = userDetails.getUser().getId();
             Long bookmarkId = bookmarkService.addBookmark(userId, newsId);
 
-            Map<String, Long> data = Map.of("bookmarkId", bookmarkId);
+            BookmarkAddResponse data = new BookmarkAddResponse(bookmarkId);
 
             return ResponseEntity.status(HttpStatus.OK).body(
                     new WrappedDTO<>(

--- a/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
@@ -35,7 +35,7 @@ public class BookmarkController {
 
             BookmarkAddResponse data = new BookmarkAddResponse(bookmarkId);
 
-            return ResponseEntity.status(HttpStatus.OK).body(
+            return ResponseEntity.status(HttpStatus.CREATED).body(
                     new WrappedDTO<>(
                             true,
                             "북마크가 성공적으로 추가되었습니다.",

--- a/backend/src/main/java/com/tamnara/backend/bookmark/dto/response/BookmarkAddResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/dto/response/BookmarkAddResponse.java
@@ -1,0 +1,10 @@
+package com.tamnara.backend.bookmark.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BookmarkAddResponse {
+    private Long bookmarkId;
+}

--- a/backend/src/main/java/com/tamnara/backend/global/dto/WrappedDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/global/dto/WrappedDTO.java
@@ -1,0 +1,17 @@
+package com.tamnara.backend.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WrappedDTO<T> {
+    private boolean success;
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+}

--- a/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.tamnara.backend.global.exception;
 
+import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.response.ErrorResponse;
 import com.tamnara.backend.user.exception.DuplicateUsernameException;
 import com.tamnara.backend.user.exception.DuplicateEmailException;
@@ -14,11 +15,14 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<?> handleCustomException(CustomException e) {
-        return ResponseEntity.status(e.getStatus()).body(Map.of(
-                "success", false,
-                "message", e.getMessage()
-        ));
+    public ResponseEntity<WrappedDTO<Void>> handleCustomException(CustomException e) {
+        return ResponseEntity
+                .status(e.getStatus())
+                .body(new WrappedDTO<>(
+                        false,
+                        e.getMessage(),
+                        null
+                ));
     }
 
     @ExceptionHandler(DuplicateUsernameException.class)

--- a/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
@@ -16,9 +16,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<WrappedDTO<Void>> handleCustomException(CustomException e) {
-        return ResponseEntity
-                .status(e.getStatus())
-                .body(new WrappedDTO<>(
+        return ResponseEntity.status(e.getStatus()).body(
+                new WrappedDTO<>(
                         false,
                         e.getMessage(),
                         null


### PR DESCRIPTION
## 연관된 이슈
Closes #99

<br/>

## 작업 내용
- [x] chore: 공통 응답 DTO `WrappedDTO`를 global.dto 패키지에 추가한다.
- [x] 에러 발생 시 예외를 처리하는 custom exception 핸들러의 응답 바디에 `WrappedDTO`를 적용한다.
- [x] `WrappedDTO<T>`에서 data 필드의 타입 T가 될 응답 DTO를 추가한다.
- [x] 북마크 기능 컨트롤러의 응답 `WrappedDTO<ResponseDTO>`를 적용한다.
- [x] 북마크 추가 성공 시 Http Status Code를 수정한다. (`200 Ok` -> `201 Created`)

<br/>

## 상세 내용
### DTO 추가
- `WrappedDTO<T>`: 공통 응답 구조 DTO로, T는 데이터 필드의 타입을 의미
- `BookmarkAddResponse`: 북마크 추가 응답 DTO

### 응답에 DTO 적용
- 북마크 추가: `ResponseEntity<WrappedDTO<BookmarkAddResponse>>` - `201 Created`
- 북마크 삭제: `ResponseEntity<WrappedDTO<Void>>` - `204 No Content`

### 응답 테스트
#### 성공
```json
{
  "success": true,
  "message": "북마크가 성공적으로 추가되었습니다.",
  "data": {
    "bookmarkId": 49
  }
}
```

#### 실패
```json
{
  "success": false,
  "message": "이미 북마크가 추가된 상태입니다."
}
```

### 확인사항
- [x] 컨트롤러에 `<Map>`, `Map.of()`가 존재하지 않는다.
- [x] 서비스에 `<Map>`, `Map.of()`가 존재하지 않는다.