### PR TITLE
[풀스택] [refactor] 북마크 기능의 서비스, 컨트롤러 로직 리팩토링

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
@@ -62,7 +62,7 @@ public class BookmarkController {
             Long userId = userDetails.getUser().getId();
             bookmarkService.deleteBookmark(userId, newsId);
 
-            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+            return ResponseEntity.noContent().build();
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {

--- a/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
@@ -31,15 +31,14 @@ public class BookmarkController {
             }
 
             Long userId = userDetails.getUser().getId();
-            Long bookmarkId = bookmarkService.addBookmark(userId, newsId);
 
-            BookmarkAddResponse data = new BookmarkAddResponse(bookmarkId);
+            BookmarkAddResponse bookmarkAddResponse = bookmarkService.addBookmark(userId, newsId);
 
             return ResponseEntity.status(HttpStatus.CREATED).body(
                     new WrappedDTO<>(
                             true,
                             "북마크가 성공적으로 추가되었습니다.",
-                            data
+                            bookmarkAddResponse
                     ));
 
         } catch (ResponseStatusException e) {
@@ -63,6 +62,7 @@ public class BookmarkController {
             bookmarkService.deleteBookmark(userId, newsId);
 
             return ResponseEntity.noContent().build();
+
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {

--- a/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkService.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkService.java
@@ -1,6 +1,8 @@
 package com.tamnara.backend.bookmark.service;
 
+import com.tamnara.backend.bookmark.dto.response.BookmarkAddResponse;
+
 public interface BookmarkService {
-    Long addBookmark(Long userId, Long newsId);
+    BookmarkAddResponse addBookmark(Long userId, Long newsId);
     void deleteBookmark(Long userId, Long newsId);
 }

--- a/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
@@ -1,6 +1,7 @@
 package com.tamnara.backend.bookmark.service;
 
 import com.tamnara.backend.bookmark.domain.Bookmark;
+import com.tamnara.backend.bookmark.dto.response.BookmarkAddResponse;
 import com.tamnara.backend.bookmark.repository.BookmarkRepository;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.repository.NewsRepository;
@@ -22,7 +23,7 @@ public class BookmarkServiceImpl implements BookmarkService {
     private final NewsRepository newsRepository;
 
     @Override
-    public Long addBookmark(Long userId, Long newsId) {
+    public BookmarkAddResponse addBookmark(Long userId, Long newsId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
 
@@ -38,7 +39,8 @@ public class BookmarkServiceImpl implements BookmarkService {
         savedBookmark.setUser(user);
         savedBookmark.setNews(news);
         bookmarkRepository.save(savedBookmark);
-        return savedBookmark.getId();
+
+        return new BookmarkAddResponse(savedBookmark.getId());
     }
 
     @Override


### PR DESCRIPTION
## 연관된 이슈
Closes #133

<br/>

## 작업 내용
- [x] 컨트롤러 내부 로직을 댓글 조회 서비스 메서드 내부로 이동시켜 로직 수정
- [x] `ResponseEntity`의 status(HttpStatus.NO_CONTENT) → noContent() 등으로 변환하여 코드 간결화
- [x] 북마크 추가 서비스 메서드의 응답 타입 변경

<br/>

## 상세 내용
### 북마크 추가 서비스 메서드 로직 수정 
- 메서드 응답 타입을 `Long` -> `BookmarkAddResponse`로 변경
- 컨트롤러에서는 Long 타입의 bookmarkId를 DTO에 넣어서 반환하던 로직을 제거하고 서비스 응답을 그대로 응답으로 활용

<br/>

### 응답의 status(HttpStatus.XXX) 변환
- `ResponseEntity.status(HttpStatus.NO_CONTENT)` → `ResponseEntity.noContent()`
- `ResponseEntity.status(HttpStatus.CREATED)`: Location 헤더에 반환할 URI가 존재하지 않으므로 유지