### PR TITLE
refactor: 공통 응답 메시지를 global 패키지의 상수 클래스에 정의

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.global.constant;
+
+public class ResponseMessage {
+    // 공통 예외 메시지
+    public static final String BAD_REQUEST = "요청 형식이 올바르지 않습니다.";
+    public static final String INTERNAL_SERVER_ERROR = "서버 내부에 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.";
+
+    // 회원 예외 메시지
+    public static final String USER_NOT_FOUND = "존재하지 않는 회원입니다.";
+    public static final String USER_NOT_CERTIFICATION = "인증되지 않은 사용자입니다.";
+
+    // 뉴스 예외 메시지
+    public static final String NEWS_NOT_FOUND = "존재하지 않는 뉴스입니다.";
+}


### PR DESCRIPTION
## 연관된 이슈
closes #140

<br/>

## 작업 내용
- [x] 공통 응답 메시지를 global.constant 패키지의 ResponseMessage 클래스에 정의

<br/>

## 상세 내용
- 공통 예외 메시지
   - `400 Bad Request` 관련 예외 메시지
   - `500 Internal Server Error` 관련 예외 메시지
- 회원 예외 메시지
   - 회원이 존재하지 않는 경우의 예외 메시지
   - 사용자가 인증되지 않은 경우의 예외 메시지
- 뉴스 예외 메시지
   - 뉴스가 존재하지 않는 경우의 예외 메시지