### PR TITLE
[풀스택] [refactor] 북마크 응답 메시지를 bookmark 패키지의 상수 클래스에 정의

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/bookmark/constant/BookmarkResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/constant/BookmarkResponseMessage.java
@@ -2,7 +2,7 @@ package com.tamnara.backend.bookmark.constant;
 
 public class BookmarkResponseMessage {
     // 북마크 성공 메시지
-    public static final String BOOKMARK_ADDED = "북마크가 성공적으로 추가되었습니다.";
+    public static final String BOOKMARK_ADDED_SUCCESS = "북마크가 성공적으로 추가되었습니다.";
 
     // 북마크 예외 메시지
     public static final String BOOKMARK_ALREADY_ADDED = "북마크가 이미 추가된 상태입니다.";

--- a/backend/src/main/java/com/tamnara/backend/bookmark/constant/BookmarkResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/constant/BookmarkResponseMessage.java
@@ -1,0 +1,10 @@
+package com.tamnara.backend.bookmark.constant;
+
+public class BookmarkResponseMessage {
+    // 북마크 성공 메시지
+    public static final String BOOKMARK_ADDED = "북마크가 성공적으로 추가되었습니다.";
+
+    // 북마크 예외 메시지
+    public static final String BOOKMARK_ALREADY_ADDED = "북마크가 이미 추가된 상태입니다.";
+    public static final String BOOKMARK_NOT_FOUND = "북마크가 존재하지 않습니다.";
+}

--- a/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
@@ -39,7 +39,7 @@ public class BookmarkController {
             return ResponseEntity.status(HttpStatus.CREATED).body(
                     new WrappedDTO<>(
                             true,
-                            BookmarkResponseMessage.BOOKMARK_ADDED,
+                            BookmarkResponseMessage.BOOKMARK_ADDED_SUCCESS,
                             bookmarkAddResponse
                     ));
 

--- a/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkController.java
@@ -1,7 +1,9 @@
 package com.tamnara.backend.bookmark.controller;
 
+import com.tamnara.backend.bookmark.constant.BookmarkResponseMessage;
 import com.tamnara.backend.bookmark.dto.response.BookmarkAddResponse;
 import com.tamnara.backend.bookmark.service.BookmarkService;
+import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.exception.CustomException;
 import com.tamnara.backend.user.security.UserDetailsImpl;
@@ -27,7 +29,7 @@ public class BookmarkController {
     public ResponseEntity<WrappedDTO<BookmarkAddResponse>> addBookmark(@PathVariable Long newsId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
             if (userDetails == null || userDetails.getUser() == null) {
-                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인된 사용자가 아닙니다.");
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ResponseMessage.USER_NOT_CERTIFICATION);
             }
 
             Long userId = userDetails.getUser().getId();
@@ -37,17 +39,17 @@ public class BookmarkController {
             return ResponseEntity.status(HttpStatus.CREATED).body(
                     new WrappedDTO<>(
                             true,
-                            "북마크가 성공적으로 추가되었습니다.",
+                            BookmarkResponseMessage.BOOKMARK_ADDED,
                             bookmarkAddResponse
                     ));
 
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_REQUEST);
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다.");
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -55,7 +57,7 @@ public class BookmarkController {
     public ResponseEntity<Void> deleteBookmark(@PathVariable Long newsId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
             if (userDetails == null || userDetails.getUser() == null) {
-                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "로그인된 사용자가 아닙니다.");
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ResponseMessage.USER_NOT_CERTIFICATION);
             }
 
             Long userId = userDetails.getUser().getId();
@@ -66,10 +68,10 @@ public class BookmarkController {
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_REQUEST);
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다.");
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
@@ -32,10 +32,8 @@ public class BookmarkServiceImpl implements BookmarkService {
         News news  = newsRepository.findById(newsId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.NEWS_NOT_FOUND));
 
-        Optional<Bookmark> bookmark = bookmarkRepository.findByUserAndNews(user, news);
-        if (bookmark.isPresent()) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, BookmarkResponseMessage.BOOKMARK_ALREADY_ADDED);
-        }
+        bookmarkRepository.findByUserAndNews(user, news)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.CONFLICT, BookmarkResponseMessage.BOOKMARK_ALREADY_ADDED));
 
         Bookmark savedBookmark = new Bookmark();
         savedBookmark.setUser(user);

--- a/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
@@ -1,8 +1,10 @@
 package com.tamnara.backend.bookmark.service;
 
+import com.tamnara.backend.bookmark.constant.BookmarkResponseMessage;
 import com.tamnara.backend.bookmark.domain.Bookmark;
 import com.tamnara.backend.bookmark.dto.response.BookmarkAddResponse;
 import com.tamnara.backend.bookmark.repository.BookmarkRepository;
+import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.repository.NewsRepository;
 import com.tamnara.backend.user.domain.User;
@@ -25,14 +27,14 @@ public class BookmarkServiceImpl implements BookmarkService {
     @Override
     public BookmarkAddResponse addBookmark(Long userId, Long newsId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
 
         News news  = newsRepository.findById(newsId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 뉴스입니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.NEWS_NOT_FOUND));
 
         Optional<Bookmark> bookmark = bookmarkRepository.findByUserAndNews(user, news);
         if (bookmark.isPresent()) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 북마크가 추가된 상태입니다.");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, BookmarkResponseMessage.BOOKMARK_ALREADY_ADDED);
         }
 
         Bookmark savedBookmark = new Bookmark();
@@ -46,14 +48,14 @@ public class BookmarkServiceImpl implements BookmarkService {
     @Override
     public void deleteBookmark(Long userId, Long newsId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
 
         News news  = newsRepository.findById(newsId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 뉴스입니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.NEWS_NOT_FOUND));
 
         Optional<Bookmark> bookmark = bookmarkRepository.findByUserAndNews(user, news);
         if (bookmark.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "북마크가 존재하지 않습니다.");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, BookmarkResponseMessage.BOOKMARK_NOT_FOUND);
         }
 
         bookmarkRepository.delete(bookmark.get());

--- a/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.global.constant;
+
+public class ResponseMessage {
+    // 공통 예외 메시지
+    public static final String BAD_REQUEST = "요청 형식이 올바르지 않습니다.";
+    public static final String INTERNAL_SERVER_ERROR = "서버 내부에 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.";
+
+    // 회원 예외 메시지
+    public static final String USER_NOT_FOUND = "존재하지 않는 회원입니다.";
+    public static final String USER_NOT_CERTIFICATION = "인증되지 않은 사용자입니다.";
+
+    // 뉴스 예외 메시지
+    public static final String NEWS_NOT_FOUND = "존재하지 않는 뉴스입니다.";
+}


### PR DESCRIPTION
## 연관된 이슈
closes #139

<br/>

## 작업 내용
- [x] `global.constant` 패키지의 `ResponseMessage` 클래스를 cherry-pick으로 가져온다.
- [x] `bookmark.constant` 패키지의 `BookmarkResponseMessage` 클래스를 추가하여 북마크용 응답 메시지 상수를 정의한다.
- [x] `bookmark` 패키지의 서비스 및 컨트롤러에 적용한다.

<br/>

## 상세 내용
- 작업 파일: `bookmark.constant.BookmarkResponseMessage`, `bookmark.service.BookmarkServiceImpl`, `bookmark.controller.BookmarkController`
- 북마크 추가 성공 메시지: `BOOKMARK_ADDED_SUCCESS`
- 북마크 예외 메시지
   - 북마크가 이미 추가된 경우: `BOOKMARK_ALREADY_ADDED`
   - 북마크가 존재하지 않는 경우: `BOOKMARK_NOT_FOUND`

### 사용법
- `@Autowired` 등의 어노테이션을 적용하여 빈에 주입하지 않는다.
- `BookmarkResponseMessage.BOOKMARK_XXX`처럼 static 접근하여 활용한다.