### PR TITLE
[풀스택] [refactor] 댓글 응답 메시지를 comment 패키지의 상수 클래스에 정의

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/comment/constant/CommentResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/constant/CommentResponseMessage.java
@@ -1,0 +1,11 @@
+package com.tamnara.backend.comment.constant;
+
+public class CommentResponseMessage {
+    // 댓글 성공 메시지
+    public static final String COMMENT_LIST_FETCH_SUCCESS = "요청하신 댓글 목록을 성공적으로 불러왔습니다.";
+    public static final String COMMENT_CREATED_SUCCESS = "댓글이 성공적으로 생성되었습니다.";
+
+    // 댓글 예외 메시지
+    public static final String COMMENT_NOT_FOUND = "존재하지 않는 댓글입니다.";
+    public static final String COMMENT_DELETE_FORBIDDEN = "댓글을 삭제할 권한이 없습니다.";
+}

--- a/backend/src/main/java/com/tamnara/backend/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/controller/CommentController.java
@@ -93,7 +93,7 @@ public class CommentController {
     public ResponseEntity<Void> deleteComment(
             @PathVariable Long newsId,
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestParam Long commentId
+            @PathVariable Long commentId
     ) {
         try {
             if (userDetails == null || userDetails.getUsername() == null) {

--- a/backend/src/main/java/com/tamnara/backend/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/controller/CommentController.java
@@ -1,9 +1,11 @@
 package com.tamnara.backend.comment.controller;
 
+import com.tamnara.backend.comment.constant.CommentResponseMessage;
 import com.tamnara.backend.comment.dto.request.CommentCreateRequest;
 import com.tamnara.backend.comment.dto.response.CommentCreateResponse;
 import com.tamnara.backend.comment.dto.response.CommentListResponse;
 import com.tamnara.backend.comment.service.CommentService;
+import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.exception.CustomException;
 import com.tamnara.backend.user.security.UserDetailsImpl;
@@ -31,7 +33,8 @@ public class CommentController {
     @GetMapping
     public ResponseEntity<WrappedDTO<CommentListResponse>> getComments(
             @PathVariable Long newsId,
-            @RequestParam(defaultValue = "0") Integer offset) {
+            @RequestParam(defaultValue = "0") Integer offset
+    ) {
 
         try {
             CommentListResponse commentListResponse = commentService.getComments(newsId, offset);
@@ -39,14 +42,14 @@ public class CommentController {
             return ResponseEntity.ok().body(
                     new WrappedDTO<> (
                         true,
-                        "요청하신 댓글 목록을 성공적으로 불러왔습니다.",
+                        CommentResponseMessage.COMMENT_LIST_FETCH_SUCCESS,
                         commentListResponse
                     ));
 
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_REQUEST);
         } catch (RuntimeException e) {
             e.printStackTrace();
             throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
@@ -54,13 +57,14 @@ public class CommentController {
     }
 
     @PostMapping
-    public ResponseEntity<WrappedDTO<CommentCreateResponse>> createComment(@PathVariable Long newsId,
-                                                                           @AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                           @RequestBody CommentCreateRequest req
+    public ResponseEntity<WrappedDTO<CommentCreateResponse>> createComment(
+            @PathVariable Long newsId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody CommentCreateRequest req
     ) {
         try {
             if (userDetails == null || userDetails.getUsername() == null) {
-                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ResponseMessage.USER_NOT_CERTIFICATION);
             }
 
             Long userId = userDetails.getUser().getId();
@@ -70,29 +74,30 @@ public class CommentController {
 
             return ResponseEntity.status(HttpStatus.CREATED).body(
                     new WrappedDTO<> (
-                        true,
-                        "댓글이 성공적으로 생성되었습니다.",
-                        commentCreateResponse
+                            true,
+                            CommentResponseMessage.COMMENT_CREATED_SUCCESS,
+                            commentCreateResponse
                     ));
 
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_REQUEST);
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<Void> deleteComment(@PathVariable Long newsId,
-                                           @AuthenticationPrincipal UserDetailsImpl userDetails,
-                                           @RequestParam Long commentId
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long newsId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam Long commentId
     ) {
         try {
             if (userDetails == null || userDetails.getUsername() == null) {
-                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ResponseMessage.USER_NOT_CERTIFICATION);
             }
 
             Long userId = userDetails.getUser().getId();
@@ -103,10 +108,10 @@ public class CommentController {
         } catch (ResponseStatusException e) {
             throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
         } catch (IllegalArgumentException e) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "요청 형식이 올바르지 않습니다.");
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_REQUEST);
         } catch (RuntimeException e) {
             e.printStackTrace();
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
@@ -1,10 +1,12 @@
 package com.tamnara.backend.comment.service;
 
+import com.tamnara.backend.comment.constant.CommentResponseMessage;
 import com.tamnara.backend.comment.domain.Comment;
-import com.tamnara.backend.comment.dto.request.CommentCreateRequest;
 import com.tamnara.backend.comment.dto.CommentDTO;
+import com.tamnara.backend.comment.dto.request.CommentCreateRequest;
 import com.tamnara.backend.comment.dto.response.CommentListResponse;
 import com.tamnara.backend.comment.repository.CommentRepository;
+import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.repository.NewsRepository;
 import com.tamnara.backend.user.domain.User;
@@ -32,7 +34,7 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public CommentListResponse getComments(Long newsId, Integer offset) {
         if (!newsRepository.existsById(newsId)) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "요청하신 댓글의 뉴스가 존재하지 않습니다.");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.NEWS_NOT_FOUND);
         }
 
         int page = offset / PAGE_SIZE;
@@ -62,10 +64,10 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public Long save(Long userId, Long newsId, CommentCreateRequest commentCreateRequest) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.NEWS_NOT_FOUND));
 
         News news = newsRepository.findById(newsId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "요청하신 댓글의 뉴스가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.NEWS_NOT_FOUND));
 
         Comment comment = new Comment();
         comment.setContent(commentCreateRequest.getContent());
@@ -79,18 +81,18 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public void delete(Long userId, Long newsId, Long commentId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
 
         News news = newsRepository.findById(newsId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "요청하신 댓글의 뉴스가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.NEWS_NOT_FOUND));
 
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "요청하신 댓글이 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, CommentResponseMessage.COMMENT_NOT_FOUND));
 
         if (comment.getUser().equals(user)) {
             commentRepository.delete(comment);
         } else {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "댓글을 삭제할 권한이 없습니다.");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, CommentResponseMessage.COMMENT_DELETE_FORBIDDEN);
         }
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.global.constant;
+
+public class ResponseMessage {
+    // 공통 예외 메시지
+    public static final String BAD_REQUEST = "요청 형식이 올바르지 않습니다.";
+    public static final String INTERNAL_SERVER_ERROR = "서버 내부에 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.";
+
+    // 회원 예외 메시지
+    public static final String USER_NOT_FOUND = "존재하지 않는 회원입니다.";
+    public static final String USER_NOT_CERTIFICATION = "인증되지 않은 사용자입니다.";
+
+    // 뉴스 예외 메시지
+    public static final String NEWS_NOT_FOUND = "존재하지 않는 뉴스입니다.";
+}


### PR DESCRIPTION
## 연관된 이슈
closes #138

<br/>

## 작업 내용
- [x] `global.constant` 패키지의 `ResponseMessage` 클래스를 cherry-pick으로 가져온다.
- [x] `bookmark.constant` 패키지의 `BookmarkResponseMessage` 클래스를 추가하여 북마크용 응답 메시지 상수를 정의한다.
- [x] `bookmark` 패키지의 서비스 및 컨트롤러에 적용한다.

<br/>

## 상세 내용
- 작업 파일: `comment.constant.CommentResponseMessage`, `comment.service.CommentServiceImpl`, `comment.controller.CommentController`
- 댓글 목록 조회 성공 메시지: `COMMENT_LIST_FETCH_SUCCESS`
- 댓글 생성 성공 메시지: `COMMENT_CREATED_SUCCESS`
- 댓글 예외 메시지
   - 댓글이 존재하지 않는 경우: `COMMENT_NOT_FOUND`
   - 댓글을 삭제할 권한이 없는 경우: `COMMENT_DELETE_FORBIDDEN`

### 사용법
- `@Autowired` 등의 어노테이션을 적용하여 빈에 주입하지 않는다.
- `CommentResponseMessage.COMMENT_XXX`처럼 static 접근하여 활용한다.