### PR TITLE
refactor: 응답 DTO 포맷 통일을 위한 UserInfoWrapper 적용, UserUpdateRequest 이름 변경 적용

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
@@ -18,8 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -103,7 +101,7 @@ public class UserController {
             @ApiResponse(responseCode = "404", description = "관련된 회원이 없습니다."),
             @ApiResponse(responseCode = "500", description = "서버 내부 에러가 발생했습니다.")
     })
-    public ResponseEntity<WrappedDTO<UserInfo>> getCurrentUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public ResponseEntity<WrappedDTO<UserInfoWrapper>> getCurrentUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
             if (userDetails == null || userDetails.getUser() == null) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
@@ -112,7 +110,8 @@ public class UserController {
             }
 
             Long userId = userDetails.getUser().getId();
-            UserInfo data = userService.getCurrentUserInfo(userId);
+            UserInfo userInfo = userService.getCurrentUserInfo(userId);
+            UserInfoWrapper data = new UserInfoWrapper(userInfo);
 
             return ResponseEntity.ok(
                     new WrappedDTO<>(true, "요청하신 정보를 성공적으로 불러왔습니다.", data)
@@ -142,7 +141,7 @@ public class UserController {
             @ApiResponse(responseCode = "500", description = "서버 내부 에러가 발생했습니다.")
     })
     public ResponseEntity<WrappedDTO<UserUpdateResponse>> updateUsername(
-            @RequestBody @Valid UserUpdateRequestDto dto,
+            @RequestBody @Valid UserUpdateRequest dto,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         try {
@@ -200,4 +199,3 @@ public class UserController {
         }
     }
 }
-

--- a/backend/src/main/java/com/tamnara/backend/user/dto/UserInfoWrapper.java
+++ b/backend/src/main/java/com/tamnara/backend/user/dto/UserInfoWrapper.java
@@ -1,0 +1,4 @@
+package com.tamnara.backend.user.dto;
+
+public record UserInfoWrapper(UserInfo user) {
+}


### PR DESCRIPTION
### 변경 사항
- `GET /users/me` API의 응답 본문을 `UserInfo` → `UserInfoWrapper`로 감쌈

- 추후 확장성을 고려해 `user` 필드로 감싼 형태로 반환

- 응답 일관성을 위해 다른 API들과 포맷을 맞춤 (`WrappedDTO<Wrapper>` 구조)

- 새로운 래퍼 클래스 `UserInfoWrapper` 생성: `record UserInfoWrapper(UserInfo user)`

- 내부적으로 `UserInfo` 조회 로직은 그대로 유지 (`userService.getCurrentUserInfo()`)
- 변경된 네이밍 적용: `UserUpdateRequestDto` → `UserUpdateRequest`

### 이유
- 응답 포맷을 통일하여 프론트엔드 파싱 편의성 및 추후 필드 확장 시 유연성 확보

- 기존 WrappedDTO<UserInfo> 형태에서 WrappedDTO<UserInfoWrapper>로 변경됨에 따라 JSON 응답 구조가 `{ user: { ... } }` 형식으로 변경됨

### 영향
- 클라이언트는 `/users/me` API 응답에서 `user`라는 키로 유저 정보를 접근해야 함

- 기존 `UserInfo` 내부 필드는 변경 없음