### PR TITLE
feat: RestTemplate Bean 등록을 위한 RestTemplateConfig 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}


### PR DESCRIPTION
### 요약
외부 API 통신에 사용할 수 있도록 `RestTemplate`을 Spring Bean으로 등록하는 `RestTemplateConfig`를 추가했습니다.

### 주요 변경사항
- `global.config` 패키지에 `RestTemplateConfig` 클래스 생성
- `@Bean` 애너테이션을 통해 `RestTemplate`을 컨테이너에 등록

### 도입 이유
`RestTemplate`을 직접 생성하지 않고 Bean으로 등록함으로써:
- 서비스 단에서 재사용 가능
- 테스트 시 Mock 주입 용이
- 타임아웃, 인터셉터 등 중앙 집중 설정 가능

### 연관 사항
- `KakaoApiClient` 등 외부 API 연동 서비스에서 DI 방식으로 사용하기 위함
