### PR TITLE
refactor: 회원 기능 응답 메시지 상수화 및 하드코딩 제거

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/user/constant/UserResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/user/constant/UserResponseMessage.java
@@ -1,0 +1,20 @@
+package com.tamnara.backend.user.constant;
+
+public class UserResponseMessage {
+    public static final String EMAIL_BAD_REQUEST = "이메일 형식이 올바르지 않습니다.";
+    public static final String EMAIL_AVAILABLE = "사용 가능한 이메일입니다.";
+    public static final String EMAIL_UNAVALIABLE = "이미 사용 중인 이메일입니다.";
+
+    public static final String NICKNAME_BAD_REQUEST = "닉네임 형식이 잘못되었습니다.";
+    public static final String NICKNAME_AVAILABLE = "사용 가능한 닉네임입니다.";
+    public static final String NICKNAME_UNAVALIABLE = "이미 사용 중인 닉네임입니다.";
+
+    public static final String USER_INFO_RETRIEVED = "요청하신 회원 정보를 성공적으로 불러왔습니다.";
+    public static final String USER_INFO_MODIFIED = "회원 정보가 성공적으로 수정되었습니다.";
+
+    public static final String ACCOUNT_FORBIDDEN = "유효하지 않은 계정입니다.";
+
+    public static final String LOGOUT_SUCCESSFUL = "정상적으로 로그아웃되었습니다.";
+
+    public static final String REGISTER_SUCCESSFUL = "회원가입이 성공적으로 완료되었습니다.";
+}

--- a/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
@@ -18,6 +18,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import static com.tamnara.backend.global.constant.ResponseMessage.*;
+import static com.tamnara.backend.user.constant.UserResponseMessage.*;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -39,20 +42,20 @@ public class UserController {
         try {
             if (email == null || !email.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")) {
                 return ResponseEntity.badRequest().body(
-                        new WrappedDTO<>(false, "이메일 형식이 잘못되었습니다.", null)
+                        new WrappedDTO<>(false, EMAIL_BAD_REQUEST, null)
                 );
             }
 
             boolean available = userService.isEmailAvailable(email);
             return ResponseEntity.ok(
                     new WrappedDTO<>(true,
-                            available ? "사용 가능한 이메일입니다." : "이미 사용 중인 이메일입니다.",
+                            available ? EMAIL_AVAILABLE : EMAIL_UNAVALIABLE,
                             new EmailAvailabilityResponse(available))
             );
 
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, "서버 내부 오류가 발생했습니다. 나중에 다시 시도해주세요.", null)
+                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
             );
         }
     }
@@ -71,20 +74,20 @@ public class UserController {
         try {
             if (nickname == null || nickname.isBlank() || nickname.length() > 10) {
                 return ResponseEntity.badRequest().body(
-                        new WrappedDTO<>(false, "닉네임 형식이 잘못되었습니다.", null)
+                        new WrappedDTO<>(false, NICKNAME_BAD_REQUEST, null)
                 );
             }
 
             boolean available = userService.isUsernameAvailable(nickname);
             return ResponseEntity.ok(
                     new WrappedDTO<>(true,
-                            available ? "사용 가능한 닉네임입니다." : "이미 사용 중인 닉네임입니다.",
+                            available ? NICKNAME_AVAILABLE : NICKNAME_UNAVALIABLE,
                             new NicknameAvailabilityResponse(available))
             );
 
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, "서버 내부 오류가 발생했습니다. 나중에 다시 시도해주세요.", null)
+                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
             );
         }
     }
@@ -114,16 +117,16 @@ public class UserController {
             UserInfoWrapper data = new UserInfoWrapper(userInfo);
 
             return ResponseEntity.ok(
-                    new WrappedDTO<>(true, "요청하신 정보를 성공적으로 불러왔습니다.", data)
+                    new WrappedDTO<>(true, USER_INFO_RETRIEVED, data)
             );
 
         } catch (UserNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    new WrappedDTO<>(false, "관련된 회원이 없습니다.", null)
+                    new WrappedDTO<>(false, USER_NOT_FOUND, null)
             );
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, "서버 내부 에러가 발생했습니다. 나중에 다시 시도해주세요.", null)
+                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
             );
         }
     }
@@ -149,21 +152,21 @@ public class UserController {
             User updatedUser = userService.updateUsername(userId, dto.getNickname());
 
             return ResponseEntity.ok(
-                    new WrappedDTO<>(true, "회원 정보가 성공적으로 수정되었습니다.",
+                    new WrappedDTO<>(true, USER_INFO_MODIFIED,
                             new UserUpdateResponse(updatedUser.getId()))
             );
 
         } catch (DuplicateUsernameException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(
-                    new WrappedDTO<>(false, "이미 사용 중인 닉네임입니다.", null)
+                    new WrappedDTO<>(false, NICKNAME_UNAVALIABLE, null)
             );
         } catch (UserNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    new WrappedDTO<>(false, "관련된 회원이 없습니다.", null)
+                    new WrappedDTO<>(false, USER_NOT_FOUND, null)
             );
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, "서버 내부 에러가 발생했습니다. 나중에 다시 시도해주세요.", null)
+                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
             );
         }
     }
@@ -184,17 +187,17 @@ public class UserController {
         try {
             if (userDetails == null || userDetails.getUser() == null) {
                 return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
-                        new WrappedDTO<>(false, "유효하지 않은 계정입니다.", null)
+                        new WrappedDTO<>(false, ACCOUNT_FORBIDDEN, null)
                 );
             }
 
             return ResponseEntity.ok(
-                    new WrappedDTO<>(true, "정상적으로 로그아웃되었습니다.", null)
+                    new WrappedDTO<>(true, LOGOUT_SUCCESSFUL, null)
             );
 
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, "서버 내부 오류가 발생했습니다. 나중에 다시 시도해주세요.", null)
+                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
             );
         }
     }

--- a/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import static com.tamnara.backend.user.constant.UserResponseMessage.REGISTER_SUCCESSFUL;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -47,7 +49,7 @@ public class UserService {
 
         return SignupResponse.builder()
                 .success(true)
-                .message("회원가입이 성공적으로 완료되었습니다.")
+                .message(REGISTER_SUCCESSFUL)
                 .data(SignupResponse.UserData.builder()
                         .userId(savedUser.getId())
                         .build())


### PR DESCRIPTION
## 관련 이슈
#161 

## 주요 변경 사항
- `UserResponseMessage` 클래스 추가: 사용자 관련 메시지를 상수로 관리
- `UserController`, `UserService` 내 문자열 하드코딩 제거
- 이메일/닉네임 유효성 검증, 회원 정보 조회/수정, 로그아웃, 회원가입 응답 등
- 공통 메시지(`INTERNAL_SERVER_ERROR`, `USER_NOT_FOUND` 등)는 `global.constant.ResponseMessage`에서 가져오도록 유지

## 기대 효과
- 응답 메시지를 중앙 집중식 관리하여 유지보수 용이
- 하드코딩 문자열 제거로 오타 및 중복 방지
- 메시지 일관성 확보로 API 응답 신뢰도 향상

