### PR TITLE
refactor: 회원 기능 예외 처리 및 메시지 통합 개선

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/user/constant/UserResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/user/constant/UserResponseMessage.java
@@ -3,18 +3,21 @@ package com.tamnara.backend.user.constant;
 public class UserResponseMessage {
     public static final String EMAIL_BAD_REQUEST = "이메일 형식이 올바르지 않습니다.";
     public static final String EMAIL_AVAILABLE = "사용 가능한 이메일입니다.";
-    public static final String EMAIL_UNAVALIABLE = "이미 사용 중인 이메일입니다.";
+    public static final String EMAIL_UNAVAILABLE = "이미 사용 중인 이메일입니다.";
 
     public static final String NICKNAME_BAD_REQUEST = "닉네임 형식이 잘못되었습니다.";
     public static final String NICKNAME_AVAILABLE = "사용 가능한 닉네임입니다.";
-    public static final String NICKNAME_UNAVALIABLE = "이미 사용 중인 닉네임입니다.";
+    public static final String NICKNAME_UNAVAILABLE = "이미 사용 중인 닉네임입니다.";
 
     public static final String USER_INFO_RETRIEVED = "요청하신 회원 정보를 성공적으로 불러왔습니다.";
     public static final String USER_INFO_MODIFIED = "회원 정보가 성공적으로 수정되었습니다.";
 
+    public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
     public static final String ACCOUNT_FORBIDDEN = "유효하지 않은 계정입니다.";
 
     public static final String LOGOUT_SUCCESSFUL = "정상적으로 로그아웃되었습니다.";
+
+    public static final String WITHDRAWAL_SUCCESSFUL ="회원 탈퇴 처리가 완료되었습니다.";
 
     public static final String REGISTER_SUCCESSFUL = "회원가입이 성공적으로 완료되었습니다.";
 }

--- a/backend/src/main/java/com/tamnara/backend/user/exception/DuplicateEmailException.java
+++ b/backend/src/main/java/com/tamnara/backend/user/exception/DuplicateEmailException.java
@@ -1,3 +1,9 @@
 package com.tamnara.backend.user.exception;
 
-public class DuplicateEmailException extends RuntimeException {}
+import static com.tamnara.backend.user.constant.UserResponseMessage.EMAIL_UNAVAILABLE;
+
+public class DuplicateEmailException extends RuntimeException {
+    public DuplicateEmailException() {
+        super(EMAIL_UNAVAILABLE);
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/user/exception/DuplicateUsernameException.java
+++ b/backend/src/main/java/com/tamnara/backend/user/exception/DuplicateUsernameException.java
@@ -1,3 +1,9 @@
 package com.tamnara.backend.user.exception;
 
-public class DuplicateUsernameException extends RuntimeException {}
+import static com.tamnara.backend.user.constant.UserResponseMessage.NICKNAME_UNAVAILABLE;
+
+public class DuplicateUsernameException extends RuntimeException {
+    public DuplicateUsernameException() {
+        super(NICKNAME_UNAVAILABLE);
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/user/exception/InactiveUserException.java
+++ b/backend/src/main/java/com/tamnara/backend/user/exception/InactiveUserException.java
@@ -1,0 +1,9 @@
+package com.tamnara.backend.user.exception;
+
+import static com.tamnara.backend.user.constant.UserResponseMessage.ACCOUNT_FORBIDDEN;
+
+public class InactiveUserException extends RuntimeException {
+    public InactiveUserException() {
+        super(ACCOUNT_FORBIDDEN);
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/user/exception/UserNotFoundException.java
+++ b/backend/src/main/java/com/tamnara/backend/user/exception/UserNotFoundException.java
@@ -1,4 +1,10 @@
 package com.tamnara.backend.user.exception;
 
-public class UserNotFoundException extends RuntimeException {}
+import static com.tamnara.backend.global.constant.ResponseMessage.USER_NOT_FOUND;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException() {
+        super(USER_NOT_FOUND);
+    }
+}
 

--- a/backend/src/test/java/com/tamnara/backend/user/controller/UserControllerIntegrationTest.java
+++ b/backend/src/test/java/com/tamnara/backend/user/controller/UserControllerIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static com.tamnara.backend.user.constant.UserResponseMessage.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -62,7 +63,7 @@ public class UserControllerIntegrationTest {
                         .param("email", "new@example.com"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.available").value(true))
-                .andExpect(jsonPath("$.message").value("사용 가능한 이메일입니다."));
+                .andExpect(jsonPath("$.message").value(EMAIL_AVAILABLE));
     }
 
     @Test
@@ -82,7 +83,7 @@ public class UserControllerIntegrationTest {
                         .param("email", "duplicate@example.com"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.available").value(false))
-                .andExpect(jsonPath("$.message").value("이미 사용 중인 이메일입니다."));
+                .andExpect(jsonPath("$.message").value(EMAIL_UNAVAILABLE));
     }
 
     @Test
@@ -93,7 +94,7 @@ public class UserControllerIntegrationTest {
                         .param("nickname", "uniqueNick"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.available").value(true))
-                .andExpect(jsonPath("$.message").value("사용 가능한 닉네임입니다."));
+                .andExpect(jsonPath("$.message").value(NICKNAME_AVAILABLE));
     }
 
     @Test
@@ -113,7 +114,7 @@ public class UserControllerIntegrationTest {
                         .param("nickname", "dupeNick"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.available").value(false))
-                .andExpect(jsonPath("$.message").value("이미 사용 중인 닉네임입니다."));
+                .andExpect(jsonPath("$.message").value(NICKNAME_UNAVAILABLE));
     }
 
     @Test
@@ -138,7 +139,7 @@ public class UserControllerIntegrationTest {
         mockMvc.perform(get("/users/me")
                         .header("Authorization", getAccessToken(user)))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.message").value("유효하지 않은 계정입니다."));
+                .andExpect(jsonPath("$.message").value(ACCOUNT_FORBIDDEN));
     }
 
     @Test
@@ -177,7 +178,7 @@ public class UserControllerIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.message").value("유효하지 않은 계정입니다."));
+                .andExpect(jsonPath("$.message").value(ACCOUNT_FORBIDDEN));
     }
 
     @Test
@@ -200,7 +201,7 @@ public class UserControllerIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value("이미 사용 중인 닉네임입니다."));
+                .andExpect(jsonPath("$.message").value(NICKNAME_UNAVAILABLE));
     }
 
     @Test
@@ -231,6 +232,6 @@ public class UserControllerIntegrationTest {
         mockMvc.perform(patch("/users/me/state")
                         .header("Authorization", getAccessToken(user)))
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.message").value("유효하지 않은 계정입니다."));
+                .andExpect(jsonPath("$.message").value(ACCOUNT_FORBIDDEN));
     }
 }

--- a/backend/src/test/java/com/tamnara/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/tamnara/backend/user/service/UserServiceTest.java
@@ -6,6 +6,7 @@ import com.tamnara.backend.user.dto.UserInfo;
 import com.tamnara.backend.user.dto.UserWithdrawInfo;
 import com.tamnara.backend.user.dto.UserWithdrawInfoWrapper;
 import com.tamnara.backend.user.exception.DuplicateUsernameException;
+import com.tamnara.backend.user.exception.InactiveUserException;
 import com.tamnara.backend.user.exception.UserNotFoundException;
 import com.tamnara.backend.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +87,7 @@ class UserServiceTest {
 
         // when, then
         assertThatThrownBy(() -> userService.getCurrentUserInfo(1L))
-                .isInstanceOf(UserNotFoundException.class);
+                .isInstanceOf(InactiveUserException.class);
     }
 
     @Test


### PR DESCRIPTION
## 회원 기능 예외 처리 및 메시지 통합 개선

### 관련 이슈
#175 

### 주요 변경 사항
- 예외 메시지 상수화
  - 중복된 하드코딩 메시지를 제거하고 `UserResponseMessage` 클래스로 통합
  - 오타 수정 (`EMAIL_UNAVALIABLE` → `EMAIL_UNAVAILABLE` 등)

- 회원 상태 검증 강화
  - 비활성(탈퇴) 회원에 대해:
    - 회원 정보 조회, 수정, 탈퇴, 로그아웃 시 `403 Forbidden` 응답 처리 추가
    - 관련 서비스 로직에서 `InactiveUserException`을 명시적으로 던지도록 리팩토링

- 예외 클래스 메시지 통합
  - `DuplicateEmailException`, `DuplicateUsernameException`, `InactiveUserException`, `UserNotFoundException` 생성자에 메시지 상수 적용

- `Controller `리팩토링
  - 상태 코드 및 메시지 응답 일관성 유지 (INVALID_TOKEN, ACCOUNT_FORBIDDEN 등)
  - Swagger 문서에 401, 403, 404, 409 응답 명시 추가

- 통합 테스트 강화
  - 비활성 회원이 API를 호출하는 경우 403을 반환하는 테스트 추가
    - `GET /users/me`
    - `PATCH /users/me`
  - 기존 메시지에 상수 사용 적용 (`EMAIL_UNAVAILABLE`, `NICKNAME_UNAVAILABLE`, `ACCOUNT_FORBIDDEN` 등)

### 테스트
- 모든 통합 테스트 및 단위 테스트 통과 확인
- 실제 비활성 상태에서의 접근 차단 여부 확인 완료

### 참고 사항
- 프론트엔드에서는 해당 메시지(`ACCOUNT_FORBIDDEN`, `INVALID_TOKEN`) 기반으로 사용자에게 안내 팝업 추가 필요
- 이후 추가될 사용자 상태 정책(`INACTIVE` 등) 확장 가능성 고려한 설계

