### PR TITLE
refactor: 회원 응답 메시지 상수 통합 및 컨트롤러 수정

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
@@ -8,6 +8,8 @@ public class ResponseMessage {
     // 회원 예외 메시지
     public static final String USER_NOT_FOUND = "존재하지 않는 회원입니다.";
     public static final String USER_NOT_CERTIFICATION = "인증되지 않은 사용자입니다.";
+    public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
+    public static final String ACCOUNT_FORBIDDEN = "유효하지 않은 계정입니다.";
 
     // 뉴스 예외 메시지
     public static final String NEWS_NOT_FOUND = "존재하지 않는 뉴스입니다.";

--- a/backend/src/main/java/com/tamnara/backend/user/constant/UserResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/user/constant/UserResponseMessage.java
@@ -12,9 +12,6 @@ public class UserResponseMessage {
     public static final String USER_INFO_RETRIEVED = "요청하신 회원 정보를 성공적으로 불러왔습니다.";
     public static final String USER_INFO_MODIFIED = "회원 정보가 성공적으로 수정되었습니다.";
 
-    public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
-    public static final String ACCOUNT_FORBIDDEN = "유효하지 않은 계정입니다.";
-
     public static final String LOGOUT_SUCCESSFUL = "정상적으로 로그아웃되었습니다.";
 
     public static final String WITHDRAWAL_SUCCESSFUL ="회원 탈퇴 처리가 완료되었습니다.";

--- a/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
@@ -171,7 +171,7 @@ public class UserController {
             return ResponseEntity.ok(
                     new WrappedDTO<>(true, USER_INFO_MODIFIED,
                             new UserUpdateResponse(updatedUser.getId()))
-            )
+            );
         } catch (DuplicateUsernameException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT).body(
                     new WrappedDTO<>(false, NICKNAME_UNAVAILABLE, null)

--- a/backend/src/main/java/com/tamnara/backend/user/exception/InactiveUserException.java
+++ b/backend/src/main/java/com/tamnara/backend/user/exception/InactiveUserException.java
@@ -1,6 +1,6 @@
 package com.tamnara.backend.user.exception;
 
-import static com.tamnara.backend.user.constant.UserResponseMessage.ACCOUNT_FORBIDDEN;
+import static com.tamnara.backend.global.constant.ResponseMessage.ACCOUNT_FORBIDDEN;
 
 public class InactiveUserException extends RuntimeException {
     public InactiveUserException() {

--- a/backend/src/test/java/com/tamnara/backend/user/controller/UserControllerIntegrationTest.java
+++ b/backend/src/test/java/com/tamnara/backend/user/controller/UserControllerIntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static com.tamnara.backend.user.constant.UserResponseMessage.*;
+import static com.tamnara.backend.global.constant.ResponseMessage.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;


### PR DESCRIPTION
##회원 응답 메시지 상수 통합 및 컨트롤러 수정
### 주요 변경사항
- `INVALID_TOKEN`, `ACCOUNT_FORBIDDEN` 상수를
`UserResponseMessage` → `ResponseMessage`로 이동하여 전역 메시지로 통합

- 기존 UserController 및 예외 클래스에서 해당 상수 사용 시 import 경로 수정

- 관련 테스트 코드(UserControllerIntegrationTest)에도 변경 사항 반영

### 변경 이유
- 동일한 메시지가 여러 도메인(user, auth)에서 중복 정의되고 있어 관리 일관성 확보를 위해 전역 상수로 분리
- 메시지 관리 책임을 `ResponseMessage`로 집중시켜 유지보수 편의성 향상

### 테스트
- `UserControllerIntegrationTest` 실행 완료
- 모든 관련 케이스에서 응답 메시지가 정상적으로 출력됨을 확인