### PR TITLE
config: RestTemplate 타임아웃 설정 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,7 +39,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/tamnara/backend/global/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/RestTemplateConfig.java
@@ -1,44 +1,23 @@
 package com.tamnara.backend.global.config;
 
-import org.apache.hc.client5.http.classic.HttpClient;
-import org.apache.hc.client5.http.config.ConnectionConfig;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
-import org.apache.hc.client5.http.io.HttpClientConnectionManager;
-
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 @Configuration
 public class RestTemplateConfig {
 
-    static final int READ_TIMEOUT = 3000;
+    static final int READ_TIMEOUT = 1500;
     static final int CONN_TIMEOUT = 3000;
 
     @Bean
-    public RestTemplate restTemplate() {
-        var factory = new HttpComponentsClientHttpRequestFactory();
-        factory.setHttpClient(createHttpClient());
-        return new RestTemplate(factory);
-    }
-
-    private HttpClient createHttpClient() {
-        return HttpClientBuilder.create()
-                .setConnectionManager(createHttpClientConnectionManager())
-                .build();
-    }
-
-    private HttpClientConnectionManager createHttpClientConnectionManager() {
-        return PoolingHttpClientConnectionManagerBuilder.create()
-                .setDefaultConnectionConfig(ConnectionConfig.custom()
-                        .setSocketTimeout(READ_TIMEOUT, TimeUnit.MILLISECONDS)
-                        .setConnectTimeout(CONN_TIMEOUT, TimeUnit.MILLISECONDS)
-                        .build())
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+                .setConnectTimeout(Duration.ofMillis(CONN_TIMEOUT))
+                .setReadTimeout(Duration.ofMillis(READ_TIMEOUT))
                 .build();
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/global/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/RestTemplateConfig.java
@@ -1,14 +1,44 @@
 package com.tamnara.backend.global.config;
 
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
-@Configuration
+import java.util.concurrent.TimeUnit;
 
+@Configuration
 public class RestTemplateConfig {
+
+    static final int READ_TIMEOUT = 3000;
+    static final int CONN_TIMEOUT = 3000;
+
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        var factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setHttpClient(createHttpClient());
+        return new RestTemplate(factory);
+    }
+
+    private HttpClient createHttpClient() {
+        return HttpClientBuilder.create()
+                .setConnectionManager(createHttpClientConnectionManager())
+                .build();
+    }
+
+    private HttpClientConnectionManager createHttpClientConnectionManager() {
+        return PoolingHttpClientConnectionManagerBuilder.create()
+                .setDefaultConnectionConfig(ConnectionConfig.custom()
+                        .setSocketTimeout(READ_TIMEOUT, TimeUnit.MILLISECONDS)
+                        .setConnectTimeout(CONN_TIMEOUT, TimeUnit.MILLISECONDS)
+                        .build())
+                .build();
     }
 }


### PR DESCRIPTION
## RestTemplate 타임아웃 설정 추가

### 주요 변경 사항
- `RestTemplate` 타임아웃 설정
  - 연결 타임아웃 (`CONN_TIMEOUT`): 3000ms (3초)
  - 읽기 타임아웃 (`READ_TIMEOUT`): 1500ms (1.5초)

- `RestTemplateBuilder` 사용
  - `RestTemplate`을 `RestTemplateBuilder`를 통해 구성하여 타임아웃을 설정
  - 더 나은 유연성과 관리성 확보

### 기대 효과
- 외부 API와의 통신에서 발생할 수 있는 타임아웃 문제를 예방하고, 보다 안정적인 서비스 운영이 가능
- 네트워크 연결에 대한 명확한 제어를 통해 서비스 응답 시간을 보다 정확하게 관리

### 참고 사항
- 이 설정은 `RestTemplate`을 사용하는 모든 외부 API 요청에 적용됨
- 타임아웃 값은 필요에 따라 조정 가능