### PR TITLE
[풀스택] [feat] 북마크한 뉴스 카드 목록 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/bookmark/constant/BookmarkResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/constant/BookmarkResponseMessage.java
@@ -3,6 +3,7 @@ package com.tamnara.backend.bookmark.constant;
 public class BookmarkResponseMessage {
     // 북마크 성공 메시지
     public static final String BOOKMARK_ADDED_SUCCESS = "북마크가 성공적으로 추가되었습니다.";
+    public static final String BOOKMARKED_NEWS_LIST_FETCH_SUCCESS = "요청하신 북마크 목록을 성공적으로 불러왔습니다.";
 
     // 북마크 예외 메시지
     public static final String BOOKMARK_ALREADY_ADDED = "북마크가 이미 추가된 상태입니다.";

--- a/backend/src/main/java/com/tamnara/backend/bookmark/constant/BookmarkServiceConstant.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/constant/BookmarkServiceConstant.java
@@ -1,0 +1,7 @@
+package com.tamnara.backend.bookmark.constant;
+
+public final class BookmarkServiceConstant {
+    private BookmarkServiceConstant() {}
+
+    public static final Integer PAGE_SIZE = 20;
+}

--- a/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkListController.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/controller/BookmarkListController.java
@@ -1,0 +1,57 @@
+package com.tamnara.backend.bookmark.controller;
+
+import com.tamnara.backend.bookmark.constant.BookmarkResponseMessage;
+import com.tamnara.backend.bookmark.dto.response.BookmarkListResponse;
+import com.tamnara.backend.bookmark.service.BookmarkService;
+import com.tamnara.backend.global.constant.ResponseMessage;
+import com.tamnara.backend.global.dto.WrappedDTO;
+import com.tamnara.backend.global.exception.CustomException;
+import com.tamnara.backend.user.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/me/bookmarks")
+public class BookmarkListController {
+
+    private final BookmarkService bookmarkService;
+
+    @GetMapping
+    public ResponseEntity<WrappedDTO<BookmarkListResponse>> findBookmarkedNewsList(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam(defaultValue = "0") Integer offset
+    ) {
+        try {
+            if (userDetails == null || userDetails.getUser() == null) {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ResponseMessage.USER_NOT_CERTIFICATION);
+            }
+
+            Long userId = userDetails.getUser().getId();
+
+            BookmarkListResponse bookmarkListResponse = bookmarkService.getBookmarkedNewsList(userId, offset);
+
+            return ResponseEntity.ok().body(
+                    new WrappedDTO<>(
+                            true,
+                            BookmarkResponseMessage.BOOKMARKED_NEWS_LIST_FETCH_SUCCESS,
+                            bookmarkListResponse
+                    ));
+
+        } catch (ResponseStatusException e) {
+            throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_REQUEST);
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/bookmark/domain/Bookmark.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/domain/Bookmark.java
@@ -34,15 +34,15 @@ public class Bookmark {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-        @ManyToOne(fetch = FetchType.LAZY)
-        @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false, updatable = false)
-        @OnDelete(action = OnDeleteAction.CASCADE)
-        private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
 
-        @ManyToOne(fetch = FetchType.LAZY)
-        @JoinColumn(name = "news_id", referencedColumnName = "id", nullable = false, updatable = false)
-        @OnDelete(action = OnDeleteAction.CASCADE)
-        private News news;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id", referencedColumnName = "id", nullable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private News news;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/src/main/java/com/tamnara/backend/bookmark/dto/response/BookmarkListResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/dto/response/BookmarkListResponse.java
@@ -1,0 +1,15 @@
+package com.tamnara.backend.bookmark.dto.response;
+
+import com.tamnara.backend.news.dto.NewsCardDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BookmarkListResponse {
+    private List<NewsCardDTO> bookmarks;
+    private int offset;
+    private boolean hasNext;
+}

--- a/backend/src/main/java/com/tamnara/backend/bookmark/repository/BookmarkRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/repository/BookmarkRepository.java
@@ -3,6 +3,8 @@ package com.tamnara.backend.bookmark.repository;
 import com.tamnara.backend.bookmark.domain.Bookmark;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,5 @@ import java.util.Optional;
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByUserAndNews(User user, News news);
+    Page<Bookmark> findByUser(User user, Pageable pageable);
 }

--- a/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkService.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkService.java
@@ -1,8 +1,10 @@
 package com.tamnara.backend.bookmark.service;
 
 import com.tamnara.backend.bookmark.dto.response.BookmarkAddResponse;
+import com.tamnara.backend.bookmark.dto.response.BookmarkListResponse;
 
 public interface BookmarkService {
     BookmarkAddResponse save(Long userId, Long newsId);
     void delete(Long userId, Long newsId);
+    BookmarkListResponse findByUserId(Long userId, Integer offset);
 }

--- a/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkService.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkService.java
@@ -6,5 +6,5 @@ import com.tamnara.backend.bookmark.dto.response.BookmarkListResponse;
 public interface BookmarkService {
     BookmarkAddResponse save(Long userId, Long newsId);
     void delete(Long userId, Long newsId);
-    BookmarkListResponse findByUserId(Long userId, Integer offset);
+    BookmarkListResponse getBookmarkedNewsList(Long userId, Integer offset);
 }

--- a/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
@@ -1,18 +1,30 @@
 package com.tamnara.backend.bookmark.service;
 
 import com.tamnara.backend.bookmark.constant.BookmarkResponseMessage;
+import com.tamnara.backend.bookmark.constant.BookmarkServiceConstant;
 import com.tamnara.backend.bookmark.domain.Bookmark;
 import com.tamnara.backend.bookmark.dto.response.BookmarkAddResponse;
+import com.tamnara.backend.bookmark.dto.response.BookmarkListResponse;
 import com.tamnara.backend.bookmark.repository.BookmarkRepository;
 import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.news.domain.News;
+import com.tamnara.backend.news.domain.NewsImage;
+import com.tamnara.backend.news.dto.NewsCardDTO;
+import com.tamnara.backend.news.repository.NewsImageRepository;
 import com.tamnara.backend.news.repository.NewsRepository;
 import com.tamnara.backend.user.domain.User;
 import com.tamnara.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +33,7 @@ public class BookmarkServiceImpl implements BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final UserRepository userRepository;
     private final NewsRepository newsRepository;
+    private final NewsImageRepository newsImageRepository;
 
     @Override
     public BookmarkAddResponse save(Long userId, Long newsId) {
@@ -53,5 +66,42 @@ public class BookmarkServiceImpl implements BookmarkService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.CONFLICT, BookmarkResponseMessage.BOOKMARK_NOT_FOUND));
 
         bookmarkRepository.delete(bookmark);
+    }
+
+    @Override
+    public BookmarkListResponse findByUserId(Long userId, Integer offset) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
+
+        int page = offset / BookmarkServiceConstant.PAGE_SIZE;
+        int nextOffset = offset + BookmarkServiceConstant.PAGE_SIZE;
+
+        Pageable pageable = PageRequest.of(page, BookmarkServiceConstant.PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Bookmark> bookmarkPage = bookmarkRepository.findByUser(user, pageable);
+        List<Bookmark> bookmarkList = bookmarkPage.getContent();
+
+        boolean hasNext = bookmarkRepository.findByUser(user, pageable).hasNext();
+
+        List<NewsCardDTO> newsCardDTOList = new ArrayList<>();
+        for (Bookmark b : bookmarkList) {
+            News news = newsRepository.findById(b.getNews().getId()).orElse(null);
+            if (news == null) { continue; }
+
+            NewsImage image = newsImageRepository.findByNewsId(b.getNews().getId()).orElse(null);
+
+            NewsCardDTO newsCardDTO = new NewsCardDTO(
+                    news.getId(),
+                    news.getTitle(),
+                    news.getSummary(),
+                    image != null ? image.getUrl() : null,
+                    news.getCategory() != null ? news.getCategory().toString() : null,
+                    news.getUpdatedAt(),
+                    true,
+                    b.getCreatedAt()
+            );
+            newsCardDTOList.add(newsCardDTO);
+        }
+
+        return new BookmarkListResponse(newsCardDTOList, nextOffset, hasNext);
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/bookmark/service/BookmarkServiceImpl.java
@@ -69,7 +69,7 @@ public class BookmarkServiceImpl implements BookmarkService {
     }
 
     @Override
-    public BookmarkListResponse findByUserId(Long userId, Integer offset) {
+    public BookmarkListResponse getBookmarkedNewsList(Long userId, Integer offset) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
 

--- a/backend/src/main/java/com/tamnara/backend/news/domain/News.java
+++ b/backend/src/main/java/com/tamnara/backend/news/domain/News.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.OnDelete;
@@ -25,6 +26,7 @@ import java.time.LocalDateTime;
 @Setter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(of = "id")
 @Table(name = "news")
 public class News {
     @Id
@@ -41,14 +43,14 @@ public class News {
     @OnDelete(action = OnDeleteAction.RESTRICT)
     private Category category;
 
-    @Column(name = "title", length = 24, nullable = false)
+    @Column(name = "title", length = 255, nullable = false)
     private String title;
 
-    @Column(name = "summary", length = 36, nullable = false)
+    @Column(name = "summary", length = 255, nullable = false)
     private String summary;
 
     @Column(name = "is_hotissue", nullable = false)
-    private Boolean isHotissue;
+    private Boolean isHotissue = false;
 
     @Column(name = "view_count", nullable = false)
     private Long viewCount = 1L;

--- a/backend/src/main/java/com/tamnara/backend/news/domain/NewsImage.java
+++ b/backend/src/main/java/com/tamnara/backend/news/domain/NewsImage.java
@@ -1,6 +1,17 @@
 package com.tamnara.backend.news.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.OnDelete;
@@ -11,6 +22,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Setter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(of = "id")
 @Table(name = "news_images", indexes = @Index(name = "idx_news_id_id", columnList = "news_id, id"))
 public class NewsImage {
     @Id

--- a/backend/src/main/java/com/tamnara/backend/news/domain/NewsTag.java
+++ b/backend/src/main/java/com/tamnara/backend/news/domain/NewsTag.java
@@ -1,6 +1,15 @@
 package com.tamnara.backend.news.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.OnDelete;
@@ -11,6 +20,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Setter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(of = "id")
 @Table(name = "news_tag")
 public class NewsTag {
     @Id

--- a/backend/src/main/java/com/tamnara/backend/news/domain/Tag.java
+++ b/backend/src/main/java/com/tamnara/backend/news/domain/Tag.java
@@ -1,6 +1,13 @@
 package com.tamnara.backend.news.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -9,6 +16,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Setter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(of = "id")
 @Table(name = "tags")
 public class Tag {
     @Id

--- a/backend/src/main/java/com/tamnara/backend/news/domain/TimelineCard.java
+++ b/backend/src/main/java/com/tamnara/backend/news/domain/TimelineCard.java
@@ -2,6 +2,7 @@ package com.tamnara.backend.news.domain;
 
 import com.tamnara.backend.news.domain.converter.StringListConverter;
 import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.OnDelete;
@@ -15,6 +16,7 @@ import java.util.List;
 @Setter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(of = "id")
 @Table(name = "timeline_cards", indexes = @Index(name = "idx_news_start_desc", columnList = "news_id, start_at DESC"))
 public class TimelineCard {
     @Id
@@ -26,7 +28,7 @@ public class TimelineCard {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private News news;
 
-    @Column(name = "title", length = 18, nullable = false)
+    @Column(name = "title", length = 255, nullable = false)
     private String title;
 
     @Column(name = "content", columnDefinition = "TEXT", nullable = false)
@@ -37,8 +39,8 @@ public class TimelineCard {
     private List<String> source;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", length = 10, nullable = false)
-    private TimelineCardType type = TimelineCardType.DAY;
+    @Column(name = "duration", length = 10, nullable = false)
+    private TimelineCardType duration = TimelineCardType.DAY;
 
     @Column(name = "start_at", nullable = false)
     private LocalDate startAt;

--- a/backend/src/main/java/com/tamnara/backend/news/dto/NewsCardDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/NewsCardDTO.java
@@ -1,0 +1,26 @@
+package com.tamnara.backend.news.dto;
+
+import com.tamnara.backend.news.domain.CategoryType;
+import com.tamnara.backend.news.util.ValueOfEnum;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class NewsCardDTO {
+    private Long id;
+//    @Length(max = 24, message = "뉴스의 제목은 24자까지만 가능합니다.")
+    private String title;
+//    @Length(max = 36, message = "뉴스의 미리보기 내용은 36자까지만 가능합니다.")
+    private String summary;
+    @Length(max = 255, message = "이미지 링크의 길이가 너무 깁니다.")
+    private String image;
+    @ValueOfEnum(enumClass = CategoryType.class, message = "카테고리 값이 올바르지 않습니다.")
+    private String category;
+    private LocalDateTime updatedAt;
+    private boolean bookmarked;
+    private LocalDateTime bookmarkedAt;
+}

--- a/backend/src/main/java/com/tamnara/backend/news/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/CategoryRepository.java
@@ -1,17 +1,15 @@
 package com.tamnara.backend.news.repository;
 
 import com.tamnara.backend.news.domain.Category;
+import com.tamnara.backend.news.domain.CategoryType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    @Query("""
-        SELECT c FROM Category c
-        ORDER BY c.num ASC
-    """)
-    List<Category> findAll();
+    List<Category> findAllByOrderByNumAsc();
+    Optional<Category> findByName(CategoryType name);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
@@ -14,27 +14,19 @@ import java.time.LocalDateTime;
 
 @Repository
 public interface NewsRepository extends JpaRepository<News, Long> {
-    @Query("""
-        SELECT n FROM News n
-        WHERE n.isHotissue = :isHotissue
-        ORDER BY n.updatedAt DESC, n.id DESC
-    """)
-    Page<News> findAllByIsHotissue(@Param("isHotissue") boolean isHotissue, Pageable pageable);
+    Page<News> findAllByIsHotissueTrueOrderByIdAsc(Pageable pageable);
+    Page<News> findByIsHotissueFalseOrderByUpdatedAtDescIdDesc(Pageable pageable);
 
     @Query("""
         SELECT n FROM News n
-        WHERE n.isHotissue = :isHotissue
+        WHERE n.isHotissue = false
           AND (
               (:categoryId IS NULL AND n.category IS NULL)
               OR (:categoryId IS NOT NULL AND n.category.id = :categoryId)
           )
         ORDER BY n.updatedAt DESC, n.id DESC
     """)
-    Page<News> findNewsByIsHotissueAndCategoryId(
-            @Param("isHotissue") boolean isHotissue,
-            @Param("categoryId") Long categoryId,
-            Pageable pageable
-    );
+    Page<News> findByIsHotissueFalseAndCategoryId(@Param("categoryId") Long categoryId, Pageable pageable);
 
     @Modifying
     @Transactional

--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsTagRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsTagRepository.java
@@ -4,6 +4,9 @@ import com.tamnara.backend.news.domain.NewsTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface NewsTagRepository extends JpaRepository<NewsTag, Long> {
+    List<NewsTag> findByNewsId(Long newsId);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/repository/TagRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/TagRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
     @Modifying
@@ -19,4 +21,6 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
         )
     """)
     void deleteAllOrphan();
+
+    Optional<Tag> findByName(String name);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/repository/TimelineCardRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/TimelineCardRepository.java
@@ -1,20 +1,13 @@
 package com.tamnara.backend.news.repository;
 
 import com.tamnara.backend.news.domain.TimelineCard;
-import com.tamnara.backend.news.domain.TimelineCardType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface TimelineCardRepository extends JpaRepository<TimelineCard, Long> {
-    @Query("""
-        SELECT t FROM TimelineCard t
-        WHERE t.news.id = :newsId
-          AND (:type IS NULL OR t.type = :type)
-        ORDER BY t.startAt DESC
-    """)
-    List<TimelineCard> findAllByNewsIdAndType(Long newsId, TimelineCardType type);
+    List<TimelineCard> findAllByNewsIdOrderByStartAtDesc(Long newsId);
+    void deleteAllByNewsId(Long newsId);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/util/ValueOfEnum.java
+++ b/backend/src/main/java/com/tamnara/backend/news/util/ValueOfEnum.java
@@ -1,0 +1,17 @@
+package com.tamnara.backend.news.util;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ValueOfEnumValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValueOfEnum {
+    Class<? extends Enum<?>> enumClass();
+    String message() default "허용되지 않은 값입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/tamnara/backend/news/util/ValueOfEnumValidator.java
+++ b/backend/src/main/java/com/tamnara/backend/news/util/ValueOfEnumValidator.java
@@ -1,0 +1,25 @@
+package com.tamnara.backend.news.util;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ValueOfEnumValidator implements ConstraintValidator<ValueOfEnum, String> {
+
+    private Set<String> acceptedValues;
+
+    @Override
+    public void initialize(ValueOfEnum annotation) {
+        acceptedValues = Arrays.stream(annotation.enumClass().getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value == null || acceptedValues.contains(value.toUpperCase());
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/bookmark/controller/BookmarkListControllerTest.java
+++ b/backend/src/test/java/com/tamnara/backend/bookmark/controller/BookmarkListControllerTest.java
@@ -1,0 +1,144 @@
+package com.tamnara.backend.bookmark.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tamnara.backend.bookmark.config.BookmarkServiceMockConfig;
+import com.tamnara.backend.bookmark.constant.BookmarkResponseMessage;
+import com.tamnara.backend.bookmark.constant.BookmarkServiceConstant;
+import com.tamnara.backend.bookmark.dto.response.BookmarkListResponse;
+import com.tamnara.backend.bookmark.service.BookmarkService;
+import com.tamnara.backend.global.constant.ResponseMessage;
+import com.tamnara.backend.news.dto.NewsCardDTO;
+import com.tamnara.backend.user.domain.Role;
+import com.tamnara.backend.user.domain.User;
+import com.tamnara.backend.user.security.UserDetailsImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = BookmarkListController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(BookmarkServiceMockConfig.class)
+@ActiveProfiles("test")
+public class BookmarkListControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BookmarkService bookmarkService;
+
+    private static final Long USER_ID = 1L;
+    private static final Long NEWS_ID = 1L;
+
+    @BeforeEach
+    void setupSecurityContext() {
+        User user = User.builder()
+                .id(USER_ID)
+                .username("테스트유저")
+                .role(Role.USER)
+                .build();
+
+        UserDetailsImpl principal = new UserDetailsImpl(user);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    private NewsCardDTO createNewsCardDTO(Long newsId) {
+        return new NewsCardDTO(
+                newsId,
+                "제목",
+                "미리보기 내용",
+                "url",
+                null,
+                LocalDateTime.now(),
+                true,
+                LocalDateTime.now()
+        );
+    }
+
+    @Test
+    void 로그아웃_상태에서_북마크_목록_조회_불가_검증() throws Exception {
+        // given
+        SecurityContextHolder.clearContext();
+
+        // when & then
+        mockMvc.perform(
+                get("/users/me/bookmarks")
+                        .param("offset", "0")
+                )
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ResponseMessage.USER_NOT_CERTIFICATION));
+    }
+
+    @Test
+    void 로그인_상태에서_북마크_목록_최초_조회_검증() throws Exception {
+        // given
+        NewsCardDTO newsCardDTO1 = createNewsCardDTO(1L);
+        NewsCardDTO newsCardDTO2 = createNewsCardDTO(2L);
+        NewsCardDTO newsCardDTO3 = createNewsCardDTO(3L);
+
+        BookmarkListResponse bookmarkListResponse = new BookmarkListResponse(
+                List.of(newsCardDTO1, newsCardDTO2, newsCardDTO3),
+                BookmarkServiceConstant.PAGE_SIZE,
+                true
+        );
+
+        given(bookmarkService.getBookmarkedNewsList(USER_ID, 0)).willReturn(bookmarkListResponse);
+
+        // when & then
+        mockMvc.perform(
+                get("/users/me/bookmarks")
+                        .param("offset", "0")
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value(BookmarkResponseMessage.BOOKMARKED_NEWS_LIST_FETCH_SUCCESS))
+                .andExpect(jsonPath("$.data.bookmarks.length()").value(3))
+                .andExpect(jsonPath("$.data.offset").value(bookmarkListResponse.getOffset()))
+                .andExpect(jsonPath("$.data.hasNext").value(true));
+    }
+
+    @Test
+    void 로그인_상태에서_북마크_목록_추가_조회_검증() throws Exception {
+        // given
+        NewsCardDTO newsCardDTO1 = createNewsCardDTO(1L);
+        NewsCardDTO newsCardDTO2 = createNewsCardDTO(2L);
+        NewsCardDTO newsCardDTO3 = createNewsCardDTO(3L);
+
+        BookmarkListResponse bookmarkListResponse = new BookmarkListResponse(
+                List.of(newsCardDTO1, newsCardDTO2, newsCardDTO3),
+                BookmarkServiceConstant.PAGE_SIZE,
+                false
+        );
+
+        given(bookmarkService.getBookmarkedNewsList(USER_ID, BookmarkServiceConstant.PAGE_SIZE)).willReturn(bookmarkListResponse);
+
+        // when & then
+        mockMvc.perform(
+                        get("/users/me/bookmarks")
+                                .param("offset", String.valueOf(BookmarkServiceConstant.PAGE_SIZE))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value(BookmarkResponseMessage.BOOKMARKED_NEWS_LIST_FETCH_SUCCESS))
+                .andExpect(jsonPath("$.data.bookmarks.length()").value(3))
+                .andExpect(jsonPath("$.data.offset").value(bookmarkListResponse.getOffset()))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/bookmark/repository/BookmarkRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/bookmark/repository/BookmarkRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.tamnara.backend.bookmark.repository;
 
+import com.tamnara.backend.bookmark.constant.BookmarkServiceConstant;
 import com.tamnara.backend.bookmark.domain.Bookmark;
 import com.tamnara.backend.global.config.JpaConfig;
 import com.tamnara.backend.news.domain.News;
@@ -17,7 +18,13 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -171,6 +178,33 @@ public class BookmarkRepositoryTest {
 
         // then
         assertEquals(bookmark.getId(), findedBookmark.getId());
+    }
+
+    @Test
+    void 회원으로_북마크_목록_조회_검증() {
+        // given
+        Bookmark bookmark1 = createBookmark(news, user);
+        bookmarkRepository.saveAndFlush(bookmark1);
+        try { Thread.sleep(1000); } catch (InterruptedException e) {}
+
+        Bookmark bookmark2 = createBookmark(news, user);
+        bookmarkRepository.saveAndFlush(bookmark2);
+        try { Thread.sleep(1000); } catch (InterruptedException e) {}
+
+        Bookmark bookmark3 = createBookmark(news, user);
+        bookmarkRepository.saveAndFlush(bookmark3);
+        em.clear();
+
+        // when
+        Pageable pageable = PageRequest.of(0, BookmarkServiceConstant.PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Bookmark> bookmarkPage = bookmarkRepository.findByUser(user, pageable);
+        List<Bookmark> bookmarkList = bookmarkPage.getContent();
+
+        // then
+        assertEquals(3, bookmarkList.size());
+        assertEquals(bookmark3, bookmarkList.get(0));
+        assertEquals(bookmark2, bookmarkList.get(1));
+        assertEquals(bookmark1, bookmarkList.get(2));
     }
 
     @Test

--- a/backend/src/test/java/com/tamnara/backend/bookmark/service/BookmarkServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/bookmark/service/BookmarkServiceImplTest.java
@@ -6,6 +6,7 @@ import com.tamnara.backend.bookmark.domain.Bookmark;
 import com.tamnara.backend.bookmark.dto.response.BookmarkAddResponse;
 import com.tamnara.backend.bookmark.dto.response.BookmarkListResponse;
 import com.tamnara.backend.bookmark.repository.BookmarkRepository;
+import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.news.domain.Category;
 import com.tamnara.backend.news.domain.CategoryType;
 import com.tamnara.backend.news.domain.News;
@@ -186,5 +187,20 @@ public class BookmarkServiceImplTest {
         assertEquals(news1.getId(), response.getBookmarks().get(2).getId());
         assertEquals(BookmarkServiceConstant.PAGE_SIZE, response.getOffset());
         assertFalse(response.isHasNext());
+    }
+
+    @Test
+    void 북마크한_뉴스_카드_목록_조회_시_회원이_존재하지_않으면_예외_처리_검증() {
+        // given
+        when(userRepository.findById(user.getId())).thenReturn(Optional.empty());
+
+        // when
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            bookmarkServiceImpl.findByUserId(user.getId(), 0);
+        });
+
+        // then
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals(ResponseMessage.USER_NOT_FOUND, exception.getReason());;
     }
 }

--- a/backend/src/test/java/com/tamnara/backend/bookmark/service/BookmarkServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/bookmark/service/BookmarkServiceImplTest.java
@@ -178,7 +178,7 @@ public class BookmarkServiceImplTest {
         when(bookmarkRepository.findByUser(user, pageable)).thenReturn(bookmarkPage);
 
         // when
-        BookmarkListResponse response = bookmarkServiceImpl.findByUserId(user.getId(), 0);
+        BookmarkListResponse response = bookmarkServiceImpl.getBookmarkedNewsList(user.getId(), 0);
 
         // then
         assertEquals(bookmarkList.size(), response.getBookmarks().size());
@@ -196,7 +196,7 @@ public class BookmarkServiceImplTest {
 
         // when
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
-            bookmarkServiceImpl.findByUserId(user.getId(), 0);
+            bookmarkServiceImpl.getBookmarkedNewsList(user.getId(), 0);
         });
 
         // then


### PR DESCRIPTION
## 연관된 뉴스
closes #210

<br/>

## 작업 내용
- [x] 북마크 목록 조회 리포지토리 메서드 추가
- [x] 북마크 목록 조회 리포지토리 메서드 검증
- [x] 북마크한 뉴스 카드 목록 조회 서비스 기능 구현
- [x] 북마크 북마크 목록 조회 서비스 메서드 검증
- [x] 북마크 목록 조회 API 추가
- [x] 북마크 목록 조회 API 검증

<br/>

## 상세 내용
### 회원의 북마크 목록 페이지 반환 메서드 추가
```java
Page<Bookmark> findByUser(User user, Pageable pageable);
```
- 북마크 리포지토리 테스트 추가
- 회원으로 북마크 목록 조회 검증
- 북마크 테이블의 `createdAt` 기준 내림차순 정렬 적용 검증
- 북마크 상수 클래스 `BookmarkServiceConstant` 추가 및 페이징 상수 `PAGE_SIZE` 정의

<br/>

### 북마크한 뉴스 카드 목록 조회 서비스 메서드 추가
```java
BookmarkListResponse getBookmarkedNewsList(Long userId, Integer offset);
```
- 북마크 목록을 불러오고, 북마크의 뉴스를 응답의 `bookmarks` 필드에 저장하여 페이징 필드 `offset`, `hasNext` 반환
- 북마크한 뉴스가 존재하지 않을 경우, 건너뛰기 -> 뉴스 카드 목록이 페이징 개수에 도달되지 않을 수 있다.
- 응답용 DTO `BookmarkListResponse` 추가
- 북마크한 뉴스 카드 목록 조회 서비스 검증
   - 회원이 북마크한 뉴스 카드 목록 조회 검증
   - 북마크한 뉴스 카드 목록 조회 시 회원이 존재하지 않으면 예외 처리 검증

<br/>

### 북마크한 뉴스 카드 목록 조회 API 추가
- 북마크 목록 조회 컨트롤러 추가: `news.controller.BookmarkListController`
- 북마크 목록 조회 API(`/user/me/bookmarks`) 추가
```java
@GetMapping
public ResponseEntity<WrappedDTO<BookmarkListResponse>> findBookmarkedNewsList
```
- 북마크 목록 조회 성공 응답 메시지 추가: `BOOKMARKED_NEWS_LIST_FETCH_SUCCESS`
- 북마크한 뉴스 카드 목록 조회 API 검증
   - 로그아웃 상태에서 북마크 목록 조회 불가 검증
   - 로그인 상태에서 북마크 목록 최초 조회 검증
   - 로그인 상태에서 북마크 목록 추가 조회 검증

