### PR TITLE
feat: 뉴스 생성 서비스 로직 보완

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsTagRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsTagRepository.java
@@ -1,12 +1,31 @@
 package com.tamnara.backend.news.repository;
 
+import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface NewsTagRepository extends JpaRepository<NewsTag, Long> {
     List<NewsTag> findByNewsId(Long newsId);
+
+    @Query(value = """
+        SELECT n.*
+        FROM news n
+        JOIN news_tag nt ON n.id = nt.news_id
+        JOIN tags t ON nt.tag_id = t.id
+        WHERE t.name IN (:keywords)
+        GROUP BY n.id
+        HAVING 
+            COUNT(DISTINCT CASE WHEN t.name IN (:keywords) THEN t.name END) = :size
+            AND COUNT(*) = :size
+        ORDER BY n.updated_at DESC
+        LIMIT 1
+    """, nativeQuery = true)
+    Optional<News> findNewsByExactlyMatchingTags(@Param("keywords") List<String> keywords, @Param("size") Integer size);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -195,6 +195,13 @@ public class NewsServiceImpl implements NewsService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
 
+        // 0. 뉴스 생성 키워드 목록과 기존 뉴스의 태그 목록이 일치할 경우, 기존 뉴스를 업데이트한다.
+        Optional<News> optionalNews = newsTagRepository.findNewsByExactlyMatchingTags(req.getKeywords(), req.getKeywords().size());
+        if (optionalNews.isPresent()) {
+            Long newsId = optionalNews.get().getId();
+            return update(newsId, userId);
+        }
+
         // 1. 뉴스의 여론 통계 생성을 비동기적으로 시작한다.
         CompletableFuture<WrappedDTO<StatisticsDTO>> statsAsync = asyncAiService
                 .getAIStatistics(req.getKeywords())

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -1,14 +1,10 @@
 package com.tamnara.backend.news.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.tamnara.backend.bookmark.domain.Bookmark;
 import com.tamnara.backend.bookmark.repository.BookmarkRepository;
 import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.exception.AIException;
-import com.tamnara.backend.news.constant.NewsExternalApiEndpoint;
 import com.tamnara.backend.news.constant.NewsResponseMessage;
 import com.tamnara.backend.news.constant.NewsServiceConstant;
 import com.tamnara.backend.news.domain.Category;
@@ -23,8 +19,6 @@ import com.tamnara.backend.news.dto.NewsCardDTO;
 import com.tamnara.backend.news.dto.NewsDetailDTO;
 import com.tamnara.backend.news.dto.StatisticsDTO;
 import com.tamnara.backend.news.dto.TimelineCardDTO;
-import com.tamnara.backend.news.dto.request.AINewsRequest;
-import com.tamnara.backend.news.dto.request.AITimelineMergeRequest;
 import com.tamnara.backend.news.dto.request.NewsCreateRequest;
 import com.tamnara.backend.news.dto.response.AINewsResponse;
 import com.tamnara.backend.news.dto.response.HotissueNewsListResponse;
@@ -45,24 +39,18 @@ import com.tamnara.backend.user.domain.Role;
 import com.tamnara.backend.user.domain.User;
 import com.tamnara.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ResponseStatusException;
-import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -71,7 +59,7 @@ import java.util.concurrent.CompletionException;
 @RequiredArgsConstructor
 public class NewsServiceImpl implements NewsService {
 
-    private final WebClient aiWebClient;
+    private final AIService aiService;
     private final AsyncAIService asyncAiService;
 
     private final NewsRepository newsRepository;
@@ -207,7 +195,7 @@ public class NewsServiceImpl implements NewsService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
 
-        // 0. 뉴스의 여론 통계 생성을 비동기적으로 시작한다.
+        // 1. 뉴스의 여론 통계 생성을 비동기적으로 시작한다.
         CompletableFuture<WrappedDTO<StatisticsDTO>> statsAsync = asyncAiService
                 .getAIStatistics(req.getKeywords())
                 .exceptionally(ex -> {
@@ -218,12 +206,12 @@ public class NewsServiceImpl implements NewsService {
                     throw new CompletionException(cause);
                 });
 
-        // 1. AI에 요청하여 뉴스를 생성한다.
+        // 2. AI에 요청하여 뉴스를 생성한다.
         AINewsResponse aiNewsResponse;
         try {
             LocalDate endAt = LocalDate.now();
             LocalDate startAt = endAt.minusDays(NewsServiceConstant.NEWS_CREATE_DAYS);
-            WrappedDTO<AINewsResponse> res = createAINews(req.getKeywords(), startAt, endAt);
+            WrappedDTO<AINewsResponse> res = aiService.createAINews(req.getKeywords(), startAt, endAt);
             aiNewsResponse = res.getData();
         } catch (AIException ex) {
             if (ex.getStatus() == HttpStatus.NOT_FOUND) {
@@ -232,15 +220,15 @@ public class NewsServiceImpl implements NewsService {
             throw ex;
         }
 
-        // 2. AI에 요청하여 타임라인 카드들을 병합한다.
-        List<TimelineCardDTO> timeline = mergeTimelineCards(aiNewsResponse.getTimeline());
+        // 3. AI에 요청하여 타임라인 카드들을 병합한다.
+        List<TimelineCardDTO> timeline = aiService.mergeTimelineCards(aiNewsResponse.getTimeline());
 
-        // 3. 뉴스의 여론 통계 생성 응답을 기다린다.
+        // 4. 뉴스의 여론 통계 생성 응답을 기다린다.
         WrappedDTO<StatisticsDTO> resStats = statsAsync.join();
         StatisticsDTO statistics = (resStats != null && resStats.getData() != null) ? resStats.getData() : null;
 
-        // 4. 저장
-        // 4-1. 뉴스를 저장한다.
+        // 5. 저장
+        // 5-1. 뉴스를 저장한다.
         Category category = null;
         if (aiNewsResponse.getCategory() != null && !aiNewsResponse.getCategory().isBlank()) {
             try {
@@ -264,16 +252,16 @@ public class NewsServiceImpl implements NewsService {
         news.setCategory(category);
         newsRepository.save(news);
 
-        // 4-2. 타임라인 카드들을 저장한다.
+        // 5-2. 타임라인 카드들을 저장한다.
         saveTimelineCards(timeline, news);
 
-        // 4-3. 뉴스 이미지를 저장한다.
+        // 5-3. 뉴스 이미지를 저장한다.
         NewsImage newsImage = new NewsImage();
         newsImage.setNews(news);
         newsImage.setUrl(aiNewsResponse.getImage());
         newsImageRepository.save(newsImage);
 
-        // 5. 뉴스 태그들을 저장하고, DB에 없는 태그를 저장한다.
+        // 5-4. 뉴스 태그들을 저장하고, DB에 없는 태그를 저장한다.
         req.getKeywords().forEach(keyword -> {
             NewsTag newsTag = new NewsTag();
             newsTag.setNews(news);
@@ -355,12 +343,12 @@ public class NewsServiceImpl implements NewsService {
                     throw new CompletionException(cause);
                 });
 
-        // 3. AI에게 요청하여 가장 최신 타임라인 카드의 endAt 이후 시점에 대한 뉴스를 생성한다.
+        // 3. AI에 요청하여 가장 최신 타임라인 카드의 endAt 이후 시점에 대한 뉴스를 생성한다.
         AINewsResponse aiNewsResponse;
         try {
             LocalDate startAt = timelineCards.getFirst().getEndAt().plusDays(1);
             LocalDate endAt = LocalDate.now();
-            WrappedDTO<AINewsResponse> res = createAINews(keywords, startAt, endAt);
+            WrappedDTO<AINewsResponse> res = aiService.createAINews(keywords, startAt, endAt);
             aiNewsResponse = res.getData();
         } catch (AIException ex) {
             if (ex.getStatus() == HttpStatus.NOT_FOUND) {
@@ -369,9 +357,9 @@ public class NewsServiceImpl implements NewsService {
             throw ex;
         }
 
-        // 4. 기존 타임라인 카드들과 합친 뒤, AI에게 요청하여 타임라인 카드들을 병합한다.
+        // 4. 기존 타임라인 카드들과 합친 뒤, AI에 요청하여 타임라인 카드들을 병합한다.
         oldTimeline.addAll(aiNewsResponse.getTimeline());
-        List<TimelineCardDTO> newTimeline = mergeTimelineCards(oldTimeline);
+        List<TimelineCardDTO> newTimeline = aiService.mergeTimelineCards(oldTimeline);
 
         // 2-2. 뉴스의 여론 통계 생성 응답을 기다린다.
         WrappedDTO<StatisticsDTO> resStats = statsAsync.join();
@@ -396,7 +384,7 @@ public class NewsServiceImpl implements NewsService {
         // 4-3. 기존 뉴스 이미지를 삭제하고 새로운 뉴스 이미지를 저장한다.
         if (newsImageRepository.findByNewsId(news.getId()).isPresent()) {
             Optional<NewsImage> oldNewsImage = newsImageRepository.findByNewsId(news.getId());
-            newsImageRepository.delete(oldNewsImage.get());
+            oldNewsImage.ifPresent(newsImageRepository::delete);
         }
         NewsImage updatedNewsImage = new NewsImage();
         updatedNewsImage.setNews(news);
@@ -441,99 +429,6 @@ public class NewsServiceImpl implements NewsService {
         }
 
         newsRepository.delete(news);
-    }
-
-
-    /*
-        AI 통신용
-     */
-
-    private WrappedDTO<AINewsResponse> createAINews(List<String> keywords, LocalDate startAt, LocalDate endAt) {
-        AINewsRequest aiNewsRequest = new AINewsRequest(
-                keywords,
-                startAt,
-                endAt
-        );
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-        return aiWebClient.post()
-                .uri(NewsExternalApiEndpoint.TIMELINE_AI_ENDPOINT)
-                .bodyValue(aiNewsRequest)
-                .retrieve()
-                .onStatus(
-                        HttpStatusCode::isError,
-                        clientResponse -> clientResponse
-                                .bodyToMono(new ParameterizedTypeReference<WrappedDTO<AINewsResponse>>() {})
-                                .flatMap(errorBody -> Mono.error(new AIException(clientResponse.statusCode(), errorBody)))
-                )
-                .bodyToMono(new ParameterizedTypeReference<WrappedDTO<AINewsResponse>>() {})
-                .block();
-    }
-
-    private List<TimelineCardDTO> mergeTimelineCards(List<TimelineCardDTO> timeline) {
-        // 1. 1일카드 -> 1주카드
-        timeline = mergeAITimelineCards(timeline, TimelineCardType.DAY, 7);
-
-        // 2. 1주카드 -> 1달카드
-        timeline = mergeAITimelineCards(timeline, TimelineCardType.WEEK, 4);
-
-        // 3. 1달카드: 3개월 지남 -> 삭제
-        timeline.removeIf(tc -> (TimelineCardType.valueOf(tc.getDuration()) == TimelineCardType.MONTH)
-                && (tc.getStartAt().isBefore(LocalDate.now().minusMonths(3))));
-
-        return timeline;
-    }
-
-    private List<TimelineCardDTO> mergeAITimelineCards(List<TimelineCardDTO> timeline, TimelineCardType duration, Integer countNum) {
-        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt));
-
-        List<TimelineCardDTO> mergedList = new ArrayList<>();
-        List<TimelineCardDTO> temp = new ArrayList<>();
-
-        int count = 0;
-
-        for (TimelineCardDTO tc : timeline) {
-            if (TimelineCardType.valueOf(tc.getDuration()) != duration) {
-                mergedList.add(tc);
-                continue;
-            }
-
-            temp.add(tc);
-            count++;
-
-            if (count == countNum) {
-                AITimelineMergeRequest mergeRequest = new AITimelineMergeRequest(temp);
-
-                WrappedDTO<TimelineCardDTO> merged = aiWebClient.post()
-                        .uri(NewsExternalApiEndpoint.MERGE_AI_ENDPOINT)
-                        .bodyValue(mergeRequest)
-                        .retrieve()
-                        .onStatus(
-                                HttpStatusCode::isError,
-                                clientResponse -> clientResponse
-                                        .bodyToMono(new ParameterizedTypeReference<WrappedDTO<TimelineCardDTO>>() {})
-                                        .flatMap(errorBody -> Mono.error(new AIException(clientResponse.statusCode(), errorBody)))
-                        )
-                        .bodyToMono(new ParameterizedTypeReference<WrappedDTO<TimelineCardDTO>>() {})
-                        .block();
-
-                mergedList.add(Objects.requireNonNull(merged).getData());
-
-                temp.clear();
-                count = 0;
-            }
-        }
-
-        mergedList.addAll(temp);
-        temp.clear();
-
-        timeline = mergedList;
-        timeline.sort(Comparator.comparing(TimelineCardDTO::getStartAt).reversed());
-
-        return timeline;
     }
 
 

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
@@ -55,6 +55,8 @@ public class NewsTagRepositoryTest {
         tag = new Tag();
         tag.setName("태그");
         tagRepository.saveAndFlush(tag);
+
+        em.clear();
     }
 
     @Test
@@ -62,6 +64,7 @@ public class NewsTagRepositoryTest {
         // given
         NewsTag newsTag = createNewsTag(news, tag);
         newsTagRepository.saveAndFlush(newsTag);
+        em.clear();
 
         // when
         NewsTag findNewsTag = newsTagRepository.findById(newsTag.getId()).get();
@@ -105,25 +108,29 @@ public class NewsTagRepositoryTest {
         // given
         NewsTag newsTag = createNewsTag(news, tag);
         newsTagRepository.saveAndFlush(newsTag);
+        em.clear();
 
         // when
         News newNews = new News();
         newNews.setTitle("제목");
         newNews.setSummary("미리보기 요약");
         newsRepository.saveAndFlush(newNews);
+        em.clear();
 
         Tag newTag = new Tag();
         newTag.setName("태그2");
         tagRepository.saveAndFlush(newTag);
+        em.clear();
 
         NewsTag findNewsTag = newsTagRepository.findById(newsTag.getId()).get();
         findNewsTag.setNews(newNews);
         findNewsTag.setTag(newTag);
         newsTagRepository.saveAndFlush(newsTag);
+        em.clear();
 
         // then
-        assertEquals(newNews, findNewsTag.getNews());
-        assertEquals(newTag, findNewsTag.getTag());
+        assertEquals(news.getId(), findNewsTag.getNews().getId());
+        assertEquals(tag.getId(), findNewsTag.getTag().getId());
     }
 
     @Test
@@ -131,22 +138,26 @@ public class NewsTagRepositoryTest {
         // given
         NewsTag newsTag = createNewsTag(news, tag);
         newsTagRepository.saveAndFlush(newsTag);
+        em.clear();
 
         // when
         NewsTag findNewsTag = newsTagRepository.findById(newsTag.getId()).get();
         newsTagRepository.delete(findNewsTag);
+        em.flush();
+        em.clear();
 
         // then
         assertFalse(newsTagRepository.existsById(newsTag.getId()));
     }
 
     @Test
-    void 뉴스_ID로_연관된_뉴스태그들_조회_검증() {
+    void 뉴스_ID로_연관된_뉴스태그들_조회_성공_검증() {
         // given
         NewsTag newsTag1 = createNewsTag(news, tag);
         newsTagRepository.saveAndFlush(newsTag1);
         NewsTag newsTag2 = createNewsTag(news, tag);
         newsTagRepository.saveAndFlush(newsTag2);
+        em.clear();
 
         // when
         List<NewsTag> findNewsTags = newsTagRepository.findByNewsId(news.getId());

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
@@ -199,4 +199,16 @@ public class NewsTagRepositoryTest {
         assertEquals(newsTag2.getId(), newsTagRepository.findByNewsId(findNews2.getId()).get(1).getId());
         assertEquals(newsTag3.getId(), newsTagRepository.findByNewsId(findNews2.getId()).get(2).getId());
     }
+
+    @Test
+    void 입력_키워드_목록과_일치하는_뉴스가_없는_경우_조회_검증() {
+        // given
+
+        // when
+        List<String> keywords = List.of(tag1.getName(), tag2.getName(), tag3.getName());
+        News findNews = newsTagRepository.findNewsByExactlyMatchingTags(keywords, keywords.size()).orElse(null);
+
+        // then
+        assertNull(findNews);
+    }
 }

--- a/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
@@ -379,6 +379,7 @@ class NewsServiceImplTest {
         // given
         List<String> query = List.of("키워드1", "키워드2", "키워드3");
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(newsTagRepository.findNewsByExactlyMatchingTags(query, query.size())).thenReturn(Optional.empty());
 
         // 타임라인 생성
         NewsCreateRequest newsCreateRequest = new NewsCreateRequest(query);
@@ -448,6 +449,121 @@ class NewsServiceImplTest {
         // then
         assertEquals(createAiNewsResponse.getData().getTitle(), response.getTitle());
         assertEquals(mergeAiNewsResponse.getFirst(), response.getTimeline().getFirst());
+        assertEquals(statisticsDTO.getData().getPositive(), response.getStatistics().getPositive());
+        assertEquals(statisticsDTO.getData().getNeutral(), response.getStatistics().getNeutral());
+        assertEquals(statisticsDTO.getData().getNegative(), response.getStatistics().getNegative());
+    }
+
+    @Test
+    void 입력_키워드_목록과_태그_목록이_동일한_뉴스가_존재하면_뉴스_생성_대신_업데이트_검증() {
+        // given
+        List<String> query = List.of("키워드1", "키워드2", "키워드3");
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+        // 타임라인 생성
+        NewsCreateRequest newsCreateRequest = new NewsCreateRequest(query);
+
+        News news = createNews(1L, "제목", "미리보기 내용", false, user, ktb);
+        news.setUpdatedAt(LocalDateTime.now().minusHours(NewsServiceConstant.NEWS_UPDATE_HOURS));
+
+        NewsImage newsImage = createNewsImage(1L, news, "url");
+
+        NewsTag newsTag1 = createNewsTag(1L, news, createTag(1L, "키워드1"));
+        NewsTag newsTag2 = createNewsTag(1L, news, createTag(2L, "키워드2"));
+        NewsTag newsTag3 = createNewsTag(1L, news, createTag(3L, "키워드3"));
+        List<NewsTag> newsTags = List.of(newsTag1, newsTag2, newsTag3);
+
+        TimelineCard weekCard = createTimelineCard(
+                news,
+                "제목",
+                "내용",
+                List.of("source1", "source2"),
+                TimelineCardType.WEEK.toString(),
+                LocalDate.now().minusDays(13),
+                LocalDate.now().minusDays(7)
+        );
+        List<TimelineCard> timelineCards = List.of(weekCard);
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(newsTagRepository.findNewsByExactlyMatchingTags(query, query.size())).thenReturn(Optional.of(news));
+        when(newsRepository.findById(news.getId())).thenReturn(Optional.of(news));
+        when(timelineCardRepository.findAllByNewsIdOrderByStartAtDesc(news.getId())).thenReturn(timelineCards);
+        when(newsTagRepository.findByNewsId(news.getId())).thenReturn(newsTags);
+        when(newsImageRepository.findByNewsId(news.getId())).thenReturn(Optional.of(newsImage));
+        when(bookmarkRepository.findByUserAndNews(user, news)).thenReturn(Optional.empty());
+
+        // 타임라인 생성
+        List<TimelineCardDTO> dayCardDTOs = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            LocalDate localDate = LocalDate.now().minusDays(i);
+
+            TimelineCardDTO dayCardDTO = new TimelineCardDTO(
+                    "제목",
+                    "내용",
+                    List.of("source1", "source2"),
+                    TimelineCardType.DAY.toString(),
+                    localDate,
+                    localDate
+            );
+
+            dayCardDTOs.add(dayCardDTO);
+        }
+
+        WrappedDTO<AINewsResponse> createAiNewsResponse = new WrappedDTO<>(
+                true,
+                "메시지",
+                new AINewsResponse(
+                        "제목",
+                        "미리보기 내용",
+                        "이미지",
+                        CategoryType.SPORTS.toString(),
+                        dayCardDTOs
+                )
+        );
+
+        when(aiService.createAINews(eq(query), eq(timelineCards.getFirst().getEndAt().plusDays(1)), eq(LocalDate.now())))
+                .thenReturn(createAiNewsResponse);
+
+        // 타임라인 병합
+        TimelineCardDTO weekCardDTO = new TimelineCardDTO(
+                weekCard.getTitle(),
+                weekCard.getContent(),
+                weekCard.getSource(),
+                weekCard.getDuration().toString(),
+                weekCard.getStartAt(),
+                weekCard.getEndAt()
+        );
+        TimelineCardDTO mergedTimelineCard = new TimelineCardDTO(
+                "제목",
+                "내용",
+                List.of("source1", "source2"),
+                TimelineCardType.WEEK.toString(),
+                LocalDate.now().minusDays(6),
+                LocalDate.now()
+        );
+        List<TimelineCardDTO> mergedResponse = List.of(mergedTimelineCard, weekCardDTO);
+        when(aiService.mergeTimelineCards(argThat(list -> list.size() == 8)))
+                .thenReturn(mergedResponse);
+
+        // 여론 통계 생성
+        WrappedDTO<StatisticsDTO> statisticsDTO = new WrappedDTO<>(
+                true,
+                "메시지",
+                new StatisticsDTO(
+                        20,
+                        30,
+                        50
+                )
+        );
+        CompletableFuture<WrappedDTO<StatisticsDTO>> statsAiResponse = CompletableFuture.completedFuture(statisticsDTO);
+        when(asyncAiService.getAIStatistics(query)).thenReturn(statsAiResponse);
+
+        // when
+        NewsDetailDTO response = newsServiceImpl.save(user.getId(), false, newsCreateRequest);
+
+        // then
+        assertEquals(createAiNewsResponse.getData().getTitle(), response.getTitle());
+        assertEquals(mergedResponse.size(), response.getTimeline().size());
         assertEquals(statisticsDTO.getData().getPositive(), response.getStatistics().getPositive());
         assertEquals(statisticsDTO.getData().getNeutral(), response.getStatistics().getNeutral());
         assertEquals(statisticsDTO.getData().getNegative(), response.getStatistics().getNegative());

--- a/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
@@ -28,6 +28,7 @@ import com.tamnara.backend.news.repository.CategoryRepository;
 import com.tamnara.backend.news.repository.NewsImageRepository;
 import com.tamnara.backend.news.repository.NewsRepository;
 import com.tamnara.backend.news.repository.NewsTagRepository;
+import com.tamnara.backend.news.repository.TagRepository;
 import com.tamnara.backend.news.repository.TimelineCardRepository;
 import com.tamnara.backend.user.domain.Role;
 import com.tamnara.backend.user.domain.State;
@@ -56,6 +57,7 @@ import java.util.concurrent.CompletableFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -73,6 +75,7 @@ class NewsServiceImplTest {
     @Mock private TimelineCardRepository timelineCardRepository;
     @Mock private NewsImageRepository newsImageRepository;
     @Mock private CategoryRepository categoryRepository;
+    @Mock private TagRepository tagRepository;
     @Mock private NewsTagRepository newsTagRepository;
 
     @Mock private UserRepository userRepository;
@@ -433,6 +436,12 @@ class NewsServiceImplTest {
         CompletableFuture<WrappedDTO<StatisticsDTO>> statsAiResponse = CompletableFuture.completedFuture(statisticsDTO);
         when(asyncAiService.getAIStatistics(query)).thenReturn(statsAiResponse);
 
+        // 뉴스 태그 저장
+        Tag tag = new Tag();
+        tag.setId(1L);
+        tag.setName("태그명");
+        when(tagRepository.findByName(any(String.class))).thenReturn(Optional.of(tag));
+
         // when
         NewsDetailDTO response = newsServiceImpl.save(user.getId(), false, newsCreateRequest);
 
@@ -603,8 +612,8 @@ class NewsServiceImplTest {
         });
 
         // then
-        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
-        assertEquals(NewsResponseMessage.NEWS_DELETE_FORBIDDEN, exception.getReason());;
+        assertEquals(HttpStatus.FORBIDDEN, exception.getStatusCode());
+        assertEquals(NewsResponseMessage.NEWS_DELETE_FORBIDDEN, exception.getReason());
     }
 
     @Test
@@ -624,6 +633,6 @@ class NewsServiceImplTest {
 
         // then
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
-        assertEquals(NewsResponseMessage.NEWS_UPDATE_CONFLICT, exception.getReason());;
+        assertEquals(NewsResponseMessage.NEWS_UPDATE_CONFLICT, exception.getReason());
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#211 

<br/>

## 작업 내용
- [x] 입력받은 키워드 목록과 태그 목록이 일치하는 뉴스를 반환하는 리포지토리 메서드 추가
- [x] 뉴스 생성 전, 입력받은 키워드 목록과 태그 목록이 일치하는 뉴스가 존재하면 업데이트하는 선행 로직 추가

<br/>

## 상세 내용
### 리포지토리 메서드 추가
- **작업한 파일:** `news.repository.NewsTagRepository`
- **작업한 내용:** 입력받은 키워드 목록과 태그 목록이 일치하는 뉴스를 반환하는 리포지토리 메서드 추가
- **테스트 목록**
   - 입력 키워드 목록과 일치하는 뉴스 조회 성공 검증
   - 입력 키워드 목록의 정렬 순서가 바뀌어도 동일한 결과 출력 확인
   - 입력 키워드 목록과 일치하는 뉴스가 없는 경우 조회 검증 추가

<br/>

### 뉴스 생성 서비스 로직 보완
- **작업한 파일:** `news.service.NewsServiceImpl`
- **작업한 내용:** 뉴스 생성 전, 입력받은 키워드 목록과 태그 목록이 일치하는 뉴스가 존재하면 업데이트하는 선행 로직 추가
- **테스트 목록**
   - 뉴스 생성 로직 내 선행 조건 분기 테스트
   - 기존 뉴스가 존재하지 않을 시 `save()` 로직 처리 검증
   - 기존 뉴스가 존재할 시 `update()` 호출 검증