### PR TITLE
refactor: 입력 키워드 목록과 태그 목록이 일치하는 뉴스 조회 메서드의 경로 변경

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsTagRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsTagRepository.java
@@ -1,31 +1,12 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsTag;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface NewsTagRepository extends JpaRepository<NewsTag, Long> {
     List<NewsTag> findByNewsId(Long newsId);
-
-    @Query(value = """
-        SELECT n.*
-        FROM news n
-        JOIN news_tag nt ON n.id = nt.news_id
-        JOIN tags t ON nt.tag_id = t.id
-        WHERE t.name IN (:keywords)
-        GROUP BY n.id
-        HAVING 
-            COUNT(DISTINCT CASE WHEN t.name IN (:keywords) THEN t.name END) = :size
-            AND COUNT(*) = :size
-        ORDER BY n.updated_at DESC
-        LIMIT 1
-    """, nativeQuery = true)
-    Optional<News> findNewsByExactlyMatchingTags(@Param("keywords") List<String> keywords, @Param("size") Integer size);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -196,7 +196,7 @@ public class NewsServiceImpl implements NewsService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
 
         // 0. 뉴스 생성 키워드 목록과 기존 뉴스의 태그 목록이 일치할 경우, 기존 뉴스를 업데이트한다.
-        Optional<News> optionalNews = newsTagRepository.findNewsByExactlyMatchingTags(req.getKeywords(), req.getKeywords().size());
+        Optional<News> optionalNews = newsRepository.findNewsByExactlyMatchingTags(req.getKeywords(), req.getKeywords().size());
         if (optionalNews.isPresent()) {
             Long newsId = optionalNews.get().getId();
             return update(newsId, userId);

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
@@ -45,7 +45,6 @@ public class NewsTagRepositoryTest {
     News news;
     Tag tag1;
     Tag tag2;
-    Tag tag3;
 
     @BeforeEach
     void setUp() {
@@ -61,10 +60,6 @@ public class NewsTagRepositoryTest {
         tag2 = new Tag();
         tag2.setName("태그2");
         tagRepository.saveAndFlush(tag2);
-
-        tag3 = new Tag();
-        tag3.setName("태그3");
-        tagRepository.saveAndFlush(tag3);
 
         em.clear();
     }
@@ -169,46 +164,5 @@ public class NewsTagRepositoryTest {
 
         // then
         assertEquals(2, findNewsTags.size());
-    }
-
-    @Test
-    void 입력_키워드_목록과_일치하는_뉴스_조회_성공_검증() {
-        // given
-        NewsTag newsTag1 = createNewsTag(news, tag1);
-        newsTagRepository.saveAndFlush(newsTag1);
-        NewsTag newsTag2 = createNewsTag(news, tag2);
-        newsTagRepository.saveAndFlush(newsTag2);
-        NewsTag newsTag3 = createNewsTag(news, tag3);
-        newsTagRepository.saveAndFlush(newsTag3);
-        em.clear();
-
-        // when
-        List<String> keywords1 = List.of(tag1.getName(), tag2.getName(), tag3.getName());
-        News findNews1 = newsTagRepository.findNewsByExactlyMatchingTags(keywords1, keywords1.size()).get();
-        List<String> keywords2 = List.of(tag2.getName(), tag1.getName(), tag3.getName());
-        News findNews2 = newsTagRepository.findNewsByExactlyMatchingTags(keywords2, keywords2.size()).get();
-
-        // then
-        assertEquals(news.getId(), findNews1.getId());
-        assertEquals(newsTag1.getId(), newsTagRepository.findByNewsId(findNews1.getId()).get(0).getId());
-        assertEquals(newsTag2.getId(), newsTagRepository.findByNewsId(findNews1.getId()).get(1).getId());
-        assertEquals(newsTag3.getId(), newsTagRepository.findByNewsId(findNews1.getId()).get(2).getId());
-
-        assertEquals(news.getId(), findNews2.getId());
-        assertEquals(newsTag1.getId(), newsTagRepository.findByNewsId(findNews2.getId()).get(0).getId());
-        assertEquals(newsTag2.getId(), newsTagRepository.findByNewsId(findNews2.getId()).get(1).getId());
-        assertEquals(newsTag3.getId(), newsTagRepository.findByNewsId(findNews2.getId()).get(2).getId());
-    }
-
-    @Test
-    void 입력_키워드_목록과_일치하는_뉴스가_없는_경우_조회_검증() {
-        // given
-
-        // when
-        List<String> keywords = List.of(tag1.getName(), tag2.getName(), tag3.getName());
-        News findNews = newsTagRepository.findNewsByExactlyMatchingTags(keywords, keywords.size()).orElse(null);
-
-        // then
-        assertNull(findNews);
     }
 }

--- a/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
@@ -379,7 +379,7 @@ class NewsServiceImplTest {
         // given
         List<String> query = List.of("키워드1", "키워드2", "키워드3");
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(newsTagRepository.findNewsByExactlyMatchingTags(query, query.size())).thenReturn(Optional.empty());
+        when(newsRepository.findNewsByExactlyMatchingTags(query, query.size())).thenReturn(Optional.empty());
 
         // 타임라인 생성
         NewsCreateRequest newsCreateRequest = new NewsCreateRequest(query);
@@ -485,7 +485,7 @@ class NewsServiceImplTest {
         List<TimelineCard> timelineCards = List.of(weekCard);
 
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(newsTagRepository.findNewsByExactlyMatchingTags(query, query.size())).thenReturn(Optional.of(news));
+        when(newsRepository.findNewsByExactlyMatchingTags(query, query.size())).thenReturn(Optional.of(news));
         when(newsRepository.findById(news.getId())).thenReturn(Optional.of(news));
         when(timelineCardRepository.findAllByNewsIdOrderByStartAtDesc(news.getId())).thenReturn(timelineCards);
         when(newsTagRepository.findByNewsId(news.getId())).thenReturn(newsTags);


### PR DESCRIPTION
## 연관된 이슈
#211 

<br/>

## 작업 내용
- [x] 입력 키워드 목록과 태그 목록이 일치하는 뉴스 조회 리포지토리 메서드를 NewsRepository로 이동
- [x] 입력 키워드 목록과 태그 목록이 일치하는 뉴스 조회 리포지토리 메서드 이동에 따른 리포지토리 테스트 코드 수정
- [x] 입력 키워드 목록과 태그 목록이 일치하는 뉴스 조회 리포지토리 메서드 이동에 따른 서비스 로직 수정
- [x] 입력 키워드 목록과 태그 목록이 일치하는 뉴스 조회 리포지토리 메서드 이동에 따른 서비스 테스트 코드 수정

<br/>

## 상세 내용
- 리포지토리 메서드 경로 변경: `news.repository.NewsTagRepository` -> `news.repository.NewsRepository`