### PR TITLE
refactor: 인증/인가 예외 처리 분리 및 응답 메시지 개선

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/global/constant/ResponseMessage.java
@@ -8,6 +8,7 @@ public class ResponseMessage {
     // 회원 예외 메시지
     public static final String USER_NOT_FOUND = "존재하지 않는 회원입니다.";
     public static final String USER_NOT_CERTIFICATION = "인증되지 않은 사용자입니다.";
+    public static final String USER_UNAUTHORIZED = "해당 요청에 대한 접근 권한이 없습니다.";
     public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
     public static final String ACCOUNT_FORBIDDEN = "유효하지 않은 계정입니다.";
 

--- a/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tamnara/backend/global/exception/GlobalExceptionHandler.java
@@ -6,10 +6,14 @@ import com.tamnara.backend.user.exception.DuplicateUsernameException;
 import com.tamnara.backend.user.exception.DuplicateEmailException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Map;
+
+import static com.tamnara.backend.global.constant.ResponseMessage.BAD_REQUEST;
+import static com.tamnara.backend.global.constant.ResponseMessage.INTERNAL_SERVER_ERROR;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -24,23 +28,24 @@ public class GlobalExceptionHandler {
                 ));
     }
 
-    @ExceptionHandler(DuplicateUsernameException.class)
-    public ResponseEntity<ErrorResponse> handleDuplicateUsernameException(DuplicateUsernameException ex) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ErrorResponse.of(false, "이미 사용 중인 닉네임입니다."));
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<WrappedDTO<Void>> handleValidationException(MethodArgumentNotValidException ex) {
+        return ResponseEntity.badRequest().body(
+                new WrappedDTO<>(false, BAD_REQUEST, null)
+        );
     }
 
-    @ExceptionHandler(DuplicateEmailException.class)
-    public ResponseEntity<ErrorResponse> handleDuplicateEmailException(DuplicateEmailException ex) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ErrorResponse.of(false, "이미 사용 중인 이메일입니다."));
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<WrappedDTO<Void>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(
+                new WrappedDTO<>(false, BAD_REQUEST, null)
+        );
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<?> handleGenericException(Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
-                "success", false,
-                "message", "서버에 문제가 발생했습니다."
-        ));
+    public ResponseEntity<WrappedDTO<Void>> handleOtherExceptions(Exception ex) {
+        return ResponseEntity.internalServerError().body(
+                new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
+        );
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/global/exception/SecurityExceptionHandler.java
+++ b/backend/src/main/java/com/tamnara/backend/global/exception/SecurityExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.tamnara.backend.global.exception;
+
+import com.tamnara.backend.global.dto.WrappedDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static com.tamnara.backend.global.constant.ResponseMessage.*;
+
+@RestControllerAdvice
+public class SecurityExceptionHandler {
+
+    // 인증 실패 (토큰 없음, 만료, 위조 등)
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<WrappedDTO<Void>> handleAuthenticationException(AuthenticationException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                new WrappedDTO<>(false, INVALID_TOKEN, null)
+        );
+    }
+
+    // 인가 실패 (ROLE 부족)
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<WrappedDTO<Void>> handleAccessDeniedException(AccessDeniedException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                new WrappedDTO<>(false, USER_UNAUTHORIZED, null)
+        );
+    }
+}


### PR DESCRIPTION
## 주요 변경사항
- `SecurityExceptionHandler` 클래스 신설
  - `AuthenticationException` → 401 Unauthorized + "유효하지 않은 토큰입니다." 반환
  - `AccessDeniedException` → 401 Unauthorized + "해당 요청에 대한 접근 권한이 없습니다." 반환
- 기존 `GlobalExceptionHandler`에서 인증 관련 예외 제거 및 정리
  - `DuplicateUsernameException`, `DuplicateEmailException`, `IllegalArgumentException`, `MethodArgumentNotValidException` 등 일반 예외 처리 유지
  - 내부 서버 오류에 대한 응답 형식을 통일 (`WrappedDTO` 사용)
- 응답 메시지 상수화
  - ResponseMessage.java에 USER_UNAUTHORIZED, INVALID_TOKEN 메시지 추가

## 목적
- 인증(Authentication)과 인가(Authorization)를 명확히 구분하여 예외 처리 구조를 개선
- 클라이언트가 에러 원인을 정확히 파악할 수 있도록 HTTP 상태코드와 메시지 일관성 확보
- 예외 응답 포맷(WrappedDTO) 통일을 통해 프론트엔드 에러 처리 코드 간소화

## 테스트 시나리오
- 토큰 누락/만료/변조 → 401 + "유효하지 않은 토큰입니다."
- 로그인은 되었지만 권한이 부족한 경우 → 401 + "해당 요청에 대한 접근 권한이 없습니다."
- 유효하지 않은 파라미터 → 400 + "잘못된 요청입니다."
- 중복 닉네임/이메일 → 409 + "이미 사용 중인 ...입니다."