### PR TITLE
feat: 뉴스 검색 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,10 +35,9 @@ out/
 
 ### VS Code ###
 .vscode/
-.DS_Store
-backend/.DS_Store
-backend/src/.DS_Store
 
-### selina 개인 파일 ###
-backend/src/main/resources/kakao
-backend/jwt_code.sh
+### Querydsl ###
+/build/
+build/generated/querydsl/
+build/generated/sources/annotationProcessor/
+src/main/generated/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ repositories {
 ext {
 	set('springCloudVersion', "2024.0.1")
 	set('tanzuScgExtensionsVersion', "1.0.0")
+	set('querydslVersion', "5.0.0")
 }
 
 dependencies {
@@ -39,6 +40,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// QueryDSL
+	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -80,4 +87,15 @@ tasks.named('test') {
 checkstyle {
 	toolVersion = '10.3.4' // 버전 수정 가능
 	configFile = file("${rootDir}/config/checkstyle/checkstyle.xml") // ✅ 규칙 파일 경로
+}
+
+// QueryDSL 설정
+def querydslDir = file("build/generated/sources/annotationProcessor/java/main")
+
+sourceSets {
+	main {
+		java {
+			srcDirs += querydslDir
+		}
+	}
 }

--- a/backend/src/main/java/com/tamnara/backend/global/config/QuerydslConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/QuerydslConfig.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/news/constant/NewsResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/news/constant/NewsResponseMessage.java
@@ -7,6 +7,8 @@ public final class NewsResponseMessage {
     public static final String HOTISSUE_NEWS_CARD_FETCH_SUCCESS = "요청하신 핫이슈 뉴스 카드 목록을 성공적으로 불러왔습니다.";
     public static final String NORMAL_NEWS_CARD_FETCH_SUCCESS = "요청하신 일반 뉴스 카드 목록을 성공적으로 불러왔습니다.";
     public static final String NORMAL_NEWS_CARD_FETCH_MORE_SUCCESS = "요청하신 일반 뉴스 카드 목록을 성공적으로 추가 로딩하였습니다.";
+    public static final String SEARCHED_NEWS_CARD_FETCH_SUCCESS = "뉴스 검색 결과를 성공적으로 불러왔습니다.";
+    public static final String SEARCHED_NEWS_CARD_FETCH_MORE_SUCCESS = "뉴스 검색 결과를 성공적으로 추가 로딩하였습니다.";
     public static final String NEWS_DETAIL_FETCH_SUCCESS = "요청하신 뉴스의 상세 정보를 성공적으로 불러왔습니다.";
     public static final String NEWS_CREATED_SUCCESS = "뉴스가 성공적으로 생성되었습니다.";
     public static final String NEWS_UPDATED_SUCCESS = "데이터가 성공적으로 업데이트되었습니다.";

--- a/backend/src/main/java/com/tamnara/backend/news/constant/NewsServiceConstant.java
+++ b/backend/src/main/java/com/tamnara/backend/news/constant/NewsServiceConstant.java
@@ -4,6 +4,8 @@ public final class NewsServiceConstant {
     private NewsServiceConstant() {}
 
     public static final Integer PAGE_SIZE = 20;
+    public static final Integer TAGS_MIN_SIZE = 1;
+    public static final Integer TAGS_MAX_SIZE = 6;
     public static final Integer STATISTICS_AI_SEARCH_CNT = 10;
     public static final Integer NEWS_CREATE_DAYS = 30;
     public static final Integer NEWS_UPDATE_HOURS = 24;

--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsSearchRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsSearchRepository.java
@@ -1,0 +1,11 @@
+package com.tamnara.backend.news.repository;
+
+import com.tamnara.backend.news.domain.News;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface NewsSearchRepository {
+    Page<News> searchNewsPageByTags(List<String> keywords, Pageable pageable);
+}

--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsSearchRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.tamnara.backend.news.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tamnara.backend.news.domain.News;
+import com.tamnara.backend.news.domain.QNews;
+import com.tamnara.backend.news.domain.QNewsTag;
+import com.tamnara.backend.news.domain.QTag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class NewsSearchRepositoryImpl implements NewsSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<News> searchNewsPageByTags(List<String> keywords, Pageable pageable) {
+        QNews news = QNews.news;
+        QTag tag = QTag.tag;
+        QNewsTag newsTag = QNewsTag.newsTag;
+
+        List<News> content = queryFactory
+                .select(news)
+                .from(newsTag)
+                .join(newsTag.news, news)
+                .join(newsTag.tag, tag)
+                .where(tag.name.in(keywords))
+                .groupBy(news.id)
+                .orderBy(
+                        tag.name.count().desc(),
+                        news.updatedAt.desc(),
+                        news.id.desc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(news.countDistinct())
+                .from(newsTag)
+                .join(newsTag.news, news)
+                .join(newsTag.tag, tag)
+                .where(tag.name.in(keywords))
+                .fetchOne();
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> total != null ? total : 0L);
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
@@ -3,12 +3,16 @@ package com.tamnara.backend.news.service;
 import com.tamnara.backend.news.dto.NewsDetailDTO;
 import com.tamnara.backend.news.dto.request.NewsCreateRequest;
 import com.tamnara.backend.news.dto.response.HotissueNewsListResponse;
+import com.tamnara.backend.news.dto.response.NewsListResponse;
 import com.tamnara.backend.news.dto.response.category.MultiCategoryResponse;
+
+import java.util.List;
 
 public interface NewsService {
     HotissueNewsListResponse getHotissueNewsCardPage();
     MultiCategoryResponse getMultiCategoryPage(Long userId, Integer offset);
     Object getSingleCategoryPage(Long userId, String category, Integer offset);
+    NewsListResponse getSearchNewsCardPage(Long userId, List<String> tags, Integer offset);
     NewsDetailDTO getNewsDetail(Long newsId, Long userId);
     NewsDetailDTO save(Long userId, boolean isHotissue, NewsCreateRequest req);
     NewsDetailDTO update(Long newsId, Long userId);

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -50,6 +50,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -153,6 +154,24 @@ public class NewsServiceImpl implements NewsService {
             case "KTB" -> new KtbResponse(newsListResponse);
             default -> throw new IllegalArgumentException();
         };
+    }
+
+    @Override
+    public NewsListResponse getSearchNewsCardPage(Long userId, List<String> tags, Integer offset) {
+        tags = new ArrayList<>(new LinkedHashSet<>(tags));
+        if (tags.size() < NewsServiceConstant.TAGS_MIN_SIZE || tags.size() > NewsServiceConstant.TAGS_MAX_SIZE) {
+            throw new IllegalArgumentException();
+        }
+
+        int page = offset / NewsServiceConstant.PAGE_SIZE;
+        int nextOffset = (page + 1) * NewsServiceConstant.PAGE_SIZE;
+        Page<News> newsPage = newsRepository.searchNewsPageByTags(tags, PageRequest.of(page, NewsServiceConstant.PAGE_SIZE));
+
+        return new NewsListResponse(
+                getNewsCardDTOList(userId, newsPage),
+                nextOffset,
+                newsPage.hasNext()
+        );
     }
 
     @Override

--- a/backend/src/test/java/com/tamnara/backend/news/controller/NewsControllerTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/controller/NewsControllerTest.java
@@ -555,6 +555,118 @@ public class NewsControllerTest {
     }
 
     @Test
+    void 로그아웃_상태에서_뉴스_검색_결과_최초_조회_검증() throws Exception {
+        // given
+        SecurityContextHolder.clearContext();
+
+        List<String> tags = List.of("태그1", "태그2", "태그3");
+
+        NewsCardDTO newsCardDTO1 = createNewsCardDTO(1L, CategoryType.KTB.toString(), LocalDateTime.now(), false);
+        NewsCardDTO newsCardDTO2 = createNewsCardDTO(2L, CategoryType.ECONOMY.name(), LocalDateTime.now(), false);
+        NewsCardDTO newsCardDTO3 = createNewsCardDTO(3L, CategoryType.ENTERTAINMENT.toString(), LocalDateTime.now(), false);
+
+        List<NewsCardDTO> newsList = List.of(newsCardDTO1, newsCardDTO2, newsCardDTO3);
+        NewsListResponse response = new NewsListResponse(newsList, NewsServiceConstant.PAGE_SIZE, false);
+        given(newsService.getSearchNewsCardPage(null, tags, 0)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                get("/news/search")
+                        .param("tags", tags.toArray(new String[0]))
+                        .param("offset", String.valueOf(0))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value(NewsResponseMessage.SEARCHED_NEWS_CARD_FETCH_SUCCESS))
+                .andExpect(jsonPath("$.data.newsList.size()").value(3))
+                .andExpect(jsonPath("$.data.offset").value(NewsServiceConstant.PAGE_SIZE))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    void 로그인_상태에서_뉴스_검색_결과_최초_조회_검증() throws Exception {
+        // given
+        List<String> tags = List.of("태그1", "태그2", "태그3");
+
+        NewsCardDTO newsCardDTO1 = createNewsCardDTO(1L, CategoryType.KTB.toString(), LocalDateTime.now(), true);
+        NewsCardDTO newsCardDTO2 = createNewsCardDTO(2L, CategoryType.ECONOMY.name(), LocalDateTime.now(), false);
+        NewsCardDTO newsCardDTO3 = createNewsCardDTO(3L, CategoryType.ENTERTAINMENT.toString(), LocalDateTime.now(), true);
+
+        List<NewsCardDTO> newsList = List.of(newsCardDTO1, newsCardDTO2, newsCardDTO3);
+        NewsListResponse response = new NewsListResponse(newsList, NewsServiceConstant.PAGE_SIZE, false);
+        given(newsService.getSearchNewsCardPage(USER_ID, tags, 0)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                        get("/news/search")
+                                .param("tags", tags.toArray(new String[0]))
+                                .param("offset", String.valueOf(0))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value(NewsResponseMessage.SEARCHED_NEWS_CARD_FETCH_SUCCESS))
+                .andExpect(jsonPath("$.data.newsList.size()").value(3))
+                .andExpect(jsonPath("$.data.offset").value(NewsServiceConstant.PAGE_SIZE))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    void 로그아웃_상태에서_뉴스_검색_결과_추가_조회_검증() throws Exception {
+        // given
+        SecurityContextHolder.clearContext();
+
+        List<String> tags = List.of("태그1", "태그2", "태그3");
+
+        NewsCardDTO newsCardDTO1 = createNewsCardDTO(1L, CategoryType.KTB.toString(), LocalDateTime.now(), false);
+        NewsCardDTO newsCardDTO2 = createNewsCardDTO(2L, CategoryType.ECONOMY.name(), LocalDateTime.now(), false);
+        NewsCardDTO newsCardDTO3 = createNewsCardDTO(3L, CategoryType.ENTERTAINMENT.toString(), LocalDateTime.now(), false);
+
+        List<NewsCardDTO> newsList = List.of(newsCardDTO1, newsCardDTO2, newsCardDTO3);
+        NewsListResponse response = new NewsListResponse(newsList, NewsServiceConstant.PAGE_SIZE * 2, false);
+        given(newsService.getSearchNewsCardPage(null, tags, NewsServiceConstant.PAGE_SIZE)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                        get("/news/search")
+                                .param("tags", tags.toArray(new String[0]))
+                                .param("offset", String.valueOf(NewsServiceConstant.PAGE_SIZE))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value(NewsResponseMessage.SEARCHED_NEWS_CARD_FETCH_MORE_SUCCESS))
+                .andExpect(jsonPath("$.data.newsList.size()").value(3))
+                .andExpect(jsonPath("$.data.offset").value(NewsServiceConstant.PAGE_SIZE * 2))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    void 로그인_상태에서_뉴스_검색_결과_추가_조회_검증() throws Exception {
+        // given
+        List<String> tags = List.of("태그1", "태그2", "태그3");
+
+        NewsCardDTO newsCardDTO1 = createNewsCardDTO(1L, CategoryType.KTB.toString(), LocalDateTime.now(), true);
+        NewsCardDTO newsCardDTO2 = createNewsCardDTO(2L, CategoryType.ECONOMY.name(), LocalDateTime.now(), false);
+        NewsCardDTO newsCardDTO3 = createNewsCardDTO(3L, CategoryType.ENTERTAINMENT.toString(), LocalDateTime.now(), true);
+
+        List<NewsCardDTO> newsList = List.of(newsCardDTO1, newsCardDTO2, newsCardDTO3);
+        NewsListResponse response = new NewsListResponse(newsList, NewsServiceConstant.PAGE_SIZE * 2, false);
+        given(newsService.getSearchNewsCardPage(USER_ID, tags, NewsServiceConstant.PAGE_SIZE)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                        get("/news/search")
+                                .param("tags", tags.toArray(new String[0]))
+                                .param("offset", String.valueOf(NewsServiceConstant.PAGE_SIZE))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value(NewsResponseMessage.SEARCHED_NEWS_CARD_FETCH_MORE_SUCCESS))
+                .andExpect(jsonPath("$.data.newsList.size()").value(3))
+                .andExpect(jsonPath("$.data.offset").value(NewsServiceConstant.PAGE_SIZE * 2))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
     void 로그아웃_상태에서_뉴스_상세_정보_조회_검증() throws Exception {
         // given
         SecurityContextHolder.clearContext();


### PR DESCRIPTION
## 연관된 이슈
closes #212 

<br/>

## 작업 내용
- [x] 뉴스 검색 리포지토리 메서드 추가
- [x] 뉴스 검색 결과 조회 서비스 메서드 추가
- [x] 뉴스 컨트롤러에 뉴스 검색 결과 조회 API 추가

<br/>

## 상세 내용
### 리포지토리 메서드 추가
- **작업한 파일:** `news.repository.NewsRepository`, `news.repository.NewsSearchRepository`, `news.repository.NewsSearchRepositoryImpl`
- **작업한 내용:**
    - QueryDSL 설정 추가하여 환경 구축하고 뉴스 검색 리포지토리 메서드 및 테스트에 적용
    - 입력받은 태그 목록에 포함되는 태그와 연관된 모든 뉴스를 (일치율 ASC, 업데이트일자 DESC, 뉴스 ID DESC) 기준으로 정렬하고 페이징 처리하여 반환하는 리포지토리 메서드 추가
- **테스트 목록**
    - 키워드 기반 뉴스 목록 검색 결과 조회 검증
        - 검색어 목록과 태그 목록이 정확히 일치하는 뉴스가 최상위에 존재하는가.
        - 검색어 목록과 교집합인 태그 목록을 가진 뉴스가 검색 결과에 포함되는가.
        - 검색어 목록의 부분집합인 태그 목록을 가진 뉴스가 검색 결과에 포함되는가.
        - 가중치가 높을수록 상위에 정렬되는가.
        - 가중치가 동일할 경우, (updatedAt DESC, id DESC) 기준으로 정렬되는가.
        - 가중치가 0인 뉴스가 검색 결과에 포함되지 않는가.

<br/>

### 서비스 메서드 추가
- **작업한 파일:** `news.service.NewsServiceImpl`
- **작업한 내용:** 입력받은 태그 목록에서 중복을 제거하고 해당되는 뉴스들을 찾아, 응답 DTO 형식에 맞춰 반환하는 서비스 메서드 추가
- **테스트 목록**
    - 뉴스 검색 결과 조회 검증
    - 태그 수 미달 시 뉴스 검색 예외 처리 검증
    - 태그 수 초과 시 뉴스 검색 예외 처리 검증
    - 뉴스 검색 시 태그 중복 제거 검증

<br/>

### API 추가
- **작업한 파일:** `news.controller.NewsController`
- **작업한 내용:** `/news/search` 엔드포인트에 해당하는 뉴스 검색 결과 조회 API 추가
- **테스트 목록**
    - 로그아웃 상태에서 뉴스 검색 결과 최초 조회 검증
    - 로그인 상태에서 뉴스 검색 결과 최초 조회 검증
    - 로그아웃 상태에서 뉴스 검색 결과 추가 조회 검증
    - 로그인 상태에서 뉴스 검색 결과 추가 조회 검증
- **스웨거로 API 테스트**
    - 최초 조회 성공
    - 추가 조회 성공
    - 검색 태그 개수 미달 시 예외 처리 확인
    - 검색 태그 개수 초과 시 예외 처리 확인