### PR TITLE
feat: 투표 통계 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/poll/controller/PollController.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/controller/PollController.java
@@ -3,17 +3,16 @@ package com.tamnara.backend.poll.controller;
 import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.poll.domain.Poll;
 import com.tamnara.backend.poll.domain.PollState;
-import com.tamnara.backend.poll.dto.PollCreateRequest;
-import com.tamnara.backend.poll.dto.PollCreateResponse;
-import com.tamnara.backend.poll.dto.PollInfoResponse;
-import com.tamnara.backend.poll.dto.VoteRequest;
+import com.tamnara.backend.poll.dto.*;
 import com.tamnara.backend.poll.service.PollService;
 import com.tamnara.backend.poll.service.VoteService;
+import com.tamnara.backend.poll.service.VoteStatisticsService;
 import com.tamnara.backend.user.domain.State;
 import com.tamnara.backend.user.domain.User;
 import com.tamnara.backend.user.security.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -23,6 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import static com.tamnara.backend.global.constant.ResponseMessage.*;
 import static com.tamnara.backend.poll.constant.PollResponseMessage.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/polls")
 @RequiredArgsConstructor
@@ -30,6 +30,7 @@ public class PollController {
 
     private final PollService pollService;
     private final VoteService voteService;
+    private final VoteStatisticsService voteStatisticsService;
 
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
@@ -105,5 +106,31 @@ public class PollController {
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 new WrappedDTO<>(true, VOTE_SUCCESS, null)
         );
+    }
+
+
+    @GetMapping("/{pollId}/stats")
+    public ResponseEntity<WrappedDTO<PollStatisticsResponse>> getPollStatistics(
+            @PathVariable Long pollId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        log.info("userDetails: {}", userDetails);
+        User user = userDetails.getUser();
+
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    new WrappedDTO<>(false, USER_NOT_FOUND, null)
+            );
+        }
+
+        if (user.getState() != State.ACTIVE) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
+                    new WrappedDTO<>(false, ACCOUNT_FORBIDDEN, null)
+            );
+        }
+
+        PollStatisticsResponse response = voteStatisticsService.getPollStatistics(pollId);
+
+        return ResponseEntity.ok(new WrappedDTO<>(true, POLL_OK, response));
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/poll/domain/VoteStatistics.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/domain/VoteStatistics.java
@@ -33,4 +33,12 @@ public class VoteStatistics {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "option_id", nullable = false)
     private PollOption option;
+
+    public static VoteStatistics zero(Poll poll, PollOption option) {
+        return VoteStatistics.builder()
+                .poll(poll)
+                .option(option)
+                .count(0L)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/tamnara/backend/poll/dto/OptionResult.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/dto/OptionResult.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.poll.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OptionResult {
+    private Long optionId;
+    private String title;
+    private long count;
+}

--- a/backend/src/main/java/com/tamnara/backend/poll/dto/PollStatisticsResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/dto/PollStatisticsResponse.java
@@ -1,0 +1,16 @@
+package com.tamnara.backend.poll.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PollStatisticsResponse {
+    private Long pollId;
+    private List<OptionResult> results;
+    private long totalVotes;
+}

--- a/backend/src/main/java/com/tamnara/backend/poll/service/VoteStatisticsService.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/service/VoteStatisticsService.java
@@ -4,6 +4,9 @@ import com.tamnara.backend.poll.domain.Poll;
 import com.tamnara.backend.poll.domain.PollOption;
 import com.tamnara.backend.poll.domain.PollState;
 import com.tamnara.backend.poll.domain.VoteStatistics;
+import com.tamnara.backend.poll.dto.OptionResult;
+import com.tamnara.backend.poll.dto.PollStatisticsResponse;
+import com.tamnara.backend.poll.exception.PollNotFoundException;
 import com.tamnara.backend.poll.repository.PollRepository;
 import com.tamnara.backend.poll.repository.VoteRepository;
 import com.tamnara.backend.poll.repository.VoteStatisticsRepository;
@@ -14,7 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StopWatch;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static com.tamnara.backend.poll.constant.PollResponseMessage.POLL_NOT_FOUND;
 import static com.tamnara.backend.poll.util.VoteStatisticsBuilder.buildNew;
 import static com.tamnara.backend.poll.util.VoteStatisticsBuilder.buildUpdated;
 
@@ -48,4 +53,22 @@ public class VoteStatisticsService {
         stopWatch.stop();
         log.info("[통계 집계 완료] 총 소요 시간: {} ms", stopWatch.getTotalTimeMillis());
     }
+
+    public PollStatisticsResponse getPollStatistics(Long pollId) {
+        Poll poll = pollRepository.findById(pollId)
+                .orElseThrow(() -> new PollNotFoundException(POLL_NOT_FOUND));
+
+        List<PollOption> options = poll.getOptions();
+
+        List<OptionResult> results = options.stream().map(option -> {
+            VoteStatistics stat = voteStatisticsRepository.findByPollIdAndOptionId(pollId, option.getId())
+                    .orElse(VoteStatistics.zero(poll, option));
+            return new OptionResult(option.getId(), option.getTitle(), stat.getCount());
+        }).collect(Collectors.toList());
+
+        long totalVotes = results.stream().mapToLong(OptionResult::getCount).sum();
+
+        return new PollStatisticsResponse(pollId, results, totalVotes);
+    }
+
 }


### PR DESCRIPTION
## feat: 투표 통계 조회 API (`GET /polls/{pollId}/stats`) 구현

### 관련 이슈
#253 

### 주요 변경사항
- `VoteStatisticsService#getPollStatistics(Long pollId)` 메서드 추가
  - 해당 투표의 모든 선택지를 대상으로 통계 조회
  - 통계가 존재하지 않으면 `VoteStatistics.zero()`로 기본값 제공
- `PollController`에 `/polls/{pollId}/stats` 엔드포인트 추가
  - 로그인 및 `State.ACTIVE` 사용자에 한해 접근 허용
- 통계 응답용 DTO 정의:
  - `PollStatisticsResponse`: 투표 ID, 전체 투표 수, 선택지별 결과 목록 포함
  - `OptionResult`: 옵션 ID, 제목, 투표 수 포함

---

### 기타 변경사항
- `VoteStatistics` 도메인에 `zero()` 정적 메서드 추가 (기본 통계 객체 생성용)

---

### 예시 응답 형식
```json
{
  "success": true,
  "message":  "요청하신 정보를 성공적으로 불러왔습니다.",
  "data": {
    "pollId": 1,
    "results": [
      { "optionId": 101, "title": "옵션 A", "count": 10 },
      { "optionId": 102, "title": "옵션 B", "count": 5 }
    ],
    "totalVotes": 15
  }
}
```


---

### 기대 효과
- 프론트엔드에서 투표 결과 시각화 가능
- 통계가 누락된 경우에도 안정적으로 0을 반환하여 UI 오류 방지

---

### 후속 작업 제안
- 유저가 투표 결과를 언제 볼 수 있는지 조건 제어 (예: 투표 종료 후 공개 등)
- 통계 캐싱 or TTL 설정 고려


---

### 테스트
200 OK (투표 결과 있는 경우)
<img width="843" alt="Image" src="https://github.com/user-attachments/assets/328bc9f3-32d0-427a-a1d9-b94e15f3dcb9" />

200 OK (투표 결과 없는 경우)
<img width="843" alt="Image" src="https://github.com/user-attachments/assets/9d1f5efe-2671-4ad7-99b0-2ff8468bb727" />

404 Not Found
<img width="846" alt="Image" src="https://github.com/user-attachments/assets/366d18f4-83fc-4f1e-86a8-6fb89301e297" />
