### PR TITLE
fix: 뉴스 상세 조회 시 뉴스의 수정일자가 현재 시점으로 변경되는 버그 해결

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
@@ -46,6 +46,10 @@ public interface NewsRepository extends JpaRepository<News, Long>, NewsSearchRep
     Optional<News> findNewsByExactlyMatchingTags(@Param("keywords") List<String> keywords, @Param("size") Integer size);
 
     @Modifying
+    @Query("UPDATE News n SET n.viewCount = n.viewCount + 1 WHERE n.id = :newsId")
+    void increaseViewCount(@Param("newsId") Long newsId);
+
+    @Modifying
     @Transactional
     @Query("""
         DELETE FROM News n

--- a/backend/src/main/java/com/tamnara/backend/news/service/AIServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/AIServiceImpl.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.exception.AIException;
+import com.tamnara.backend.news.constant.NewsExternalApiEndpoint;
 import com.tamnara.backend.news.domain.TimelineCardType;
 import com.tamnara.backend.news.dto.TimelineCardDTO;
 import com.tamnara.backend.news.dto.request.AINewsRequest;
@@ -29,9 +30,6 @@ public class AIServiceImpl implements AIService {
 
     private final WebClient aiWebClient;
 
-    private final String TIMELINE_AI_ENDPOINT = "/timeline";
-    private final String MERGE_AI_ENDPOINT = "/merge";
-
     public WrappedDTO<AINewsResponse> createAINews(List<String> keywords, LocalDate startAt, LocalDate endAt) {
         AINewsRequest aiNewsRequest = new AINewsRequest(
                 keywords,
@@ -44,7 +42,7 @@ public class AIServiceImpl implements AIService {
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         return aiWebClient.post()
-                .uri(TIMELINE_AI_ENDPOINT)
+                .uri(NewsExternalApiEndpoint.TIMELINE_AI_ENDPOINT)
                 .bodyValue(aiNewsRequest)
                 .retrieve()
                 .onStatus(
@@ -92,7 +90,7 @@ public class AIServiceImpl implements AIService {
                 AITimelineMergeRequest mergeRequest = new AITimelineMergeRequest(temp);
 
                 WrappedDTO<TimelineCardDTO> merged = aiWebClient.post()
-                        .uri(MERGE_AI_ENDPOINT)
+                        .uri(NewsExternalApiEndpoint.MERGE_AI_ENDPOINT)
                         .bodyValue(mergeRequest)
                         .retrieve()
                         .onStatus(

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -194,8 +194,7 @@ public class NewsServiceImpl implements NewsService {
         StatisticsDTO statistics = getStatisticsDTO(news);
         boolean bookmarked = user.map(u -> getBookmarked(u, news)).orElse(false);
 
-        news.setViewCount(news.getViewCount() + 1);
-        newsRepository.save(news);
+        newsRepository.increaseViewCount(news.getId());
 
         return new NewsDetailDTO(
                 news.getId(),

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -273,6 +274,25 @@ public class NewsRepositoryTest {
         // then
         News updatedNews = newsRepository.findById(news.getId()).get();
         assertFalse(updatedNews.getIsHotissue());
+    }
+
+    @Test
+    void 뉴스_조회수_증가_시_수정일자_변경되지_않고_유지_검증() {
+        // given
+        News news = createNews("제목", "미리보기 내용", user, category);
+        newsRepository.saveAndFlush(news);
+        Long viewCount = news.getViewCount();
+        LocalDateTime updateTime = news.getUpdatedAt();
+
+        // when
+        newsRepository.increaseViewCount(news.getId());
+        em.flush();
+        em.clear();
+
+        // then
+        News updatedNews = newsRepository.findById(news.getId()).get();
+        assertEquals(viewCount + 1, updatedNews.getViewCount());
+        assertEquals(updateTime.truncatedTo(ChronoUnit.SECONDS), updatedNews.getUpdatedAt().truncatedTo(ChronoUnit.SECONDS));
     }
 
     @Test


### PR DESCRIPTION
## 연관된 이슈
closes #262

<br/>

## 작업 내용
- [x] 조회수 증가 리포지토리 메서드 추가 및 테스트
- [x] 뉴스 상세 조회 서비스 메서드에서 기존 조회수 증가 로직을 리포지토리 호출로 대체

<br/>

## 상세 내용
### 리포지토리 메서드 추가
- **작업한 파일:** `news.repository.NewsRepository`
- **작업한 내용:** 조회수 증가 리포지토리 메서드 추가
- **테스트 목록**: 뉴스 조회수 증가 시 수정일자 변경되지 않고 유지 검증

<br/>

### 서비스 로직 변경
- **작업한 파일:** `news.service.NewsServiceImpl`
- **작업한 내용:** `getNewsDetail()`의 기존 조회수 증가 로직을 리포지토리 호출로 대체

<br/>

### 해결
- 응답의 `updatedAt`이 과거로 나타나는 것을 확인

![Image](https://github.com/user-attachments/assets/090376f4-d499-4bc7-994e-0bce38df9e3c)

    
- DB의 `updated_at`이 변경되지 않고, `view_count`가 1 올라가는 것을 확인

![Image](https://github.com/user-attachments/assets/81cb10af-244b-424c-af76-0c6794b65005)

![Image](https://github.com/user-attachments/assets/3abdc372-0962-4716-993d-ff9b5e8a60a4)