### PR TITLE
chore: 테스트 유틸리티 클래스 위치 이동 및 네이밍 정리

### DIFF
--- a/backend/src/test/java/com/tamnara/backend/auth/service/KakaoServiceTest.java
+++ b/backend/src/test/java/com/tamnara/backend/auth/service/KakaoServiceTest.java
@@ -2,7 +2,7 @@ package com.tamnara.backend.auth.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tamnara.backend.auth.client.KakaoApiClient;
-import com.tamnara.backend.utils.TestUtils;
+import com.tamnara.backend.global.util.TestUtil;
 import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.global.jwt.JwtProvider;
 import com.tamnara.backend.user.domain.Role;
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.tamnara.backend.auth.constant.AuthResponseMessage.KAKAO_LOGIN_SUCCESSFUL;
-import static com.tamnara.backend.utils.CreateUserUtils.createActiveUser;
+import static com.tamnara.backend.global.util.CreateUserUtil.createActiveUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -48,8 +48,8 @@ class KakaoServiceTest {
         MockitoAnnotations.openMocks(this);
         // private 필드 주입
         kakaoService = new KakaoService(userRepository, jwtProvider, kakaoApiClient);
-        TestUtils.setPrivateField(kakaoService, "clientId", "fake-client-id");
-        TestUtils.setPrivateField(kakaoService, "redirectUri", "http://fake-localhost:8080/auth/kakao/callback");
+        TestUtil.setPrivateField(kakaoService, "clientId", "fake-client-id");
+        TestUtil.setPrivateField(kakaoService, "redirectUri", "http://fake-localhost:8080/auth/kakao/callback");
     }
 
     @Test

--- a/backend/src/test/java/com/tamnara/backend/global/util/CreateUserUtil.java
+++ b/backend/src/test/java/com/tamnara/backend/global/util/CreateUserUtil.java
@@ -1,4 +1,4 @@
-package com.tamnara.backend.utils;
+package com.tamnara.backend.global.util;
 
 import com.tamnara.backend.user.domain.Role;
 import com.tamnara.backend.user.domain.State;
@@ -6,7 +6,7 @@ import com.tamnara.backend.user.domain.User;
 
 import java.time.LocalDateTime;
 
-public class CreateUserUtils {
+public class CreateUserUtil {
     public static User createActiveUser(String email, String username, String provider, String providerId) {
         return User.builder()
                 .email(email)

--- a/backend/src/test/java/com/tamnara/backend/global/util/TestUtil.java
+++ b/backend/src/test/java/com/tamnara/backend/global/util/TestUtil.java
@@ -1,6 +1,6 @@
-package com.tamnara.backend.utils;
+package com.tamnara.backend.global.util;
 
-public class TestUtils {
+public class TestUtil {
     public static void setPrivateField(Object target, String fieldName, Object value) {
         try {
             var field = target.getClass().getDeclaredField(fieldName);


### PR DESCRIPTION
## chore: 테스트 유틸리티 클래스 위치 이동 및 네이밍 정리

### 변경사항
- `CreateUserUtils` → `CreateUserUtil`로 클래스명 변경 및 `global.util` 패키지로 이동
- `TestUtils` → `TestUtil`로 클래스명 변경 및 `global.util` 패키지로 이동
- 테스트 코드(`KakaoServiceTest`) 내 import 경로 및 클래스명 전반 수정

---

### 목적
- 테스트 유틸 클래스들을 프로젝트 내 공통 유틸리티 위치(`global.util`)로 이동하여 구조 통일
- 클래스명 접미사 `Utils` → `Util`로 일관성 있는 네이밍 적용

---

### 기대 효과
- 테스트 유틸 관리 편의성 향상
- 실제 서비스 유틸리티와 테스트 유틸리티의 명확한 분리

---

### 영향
- 테스트 코드 외 기능 로직에는 영향 없음
- 향후 다른 테스트 클래스에서도 공통 유틸을 재사용 가능
