### PR TITLE
test: Poll 도메인 관련 Repository 단위 테스트 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/poll/domain/VoteStatistics.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/domain/VoteStatistics.java
@@ -3,10 +3,12 @@ package com.tamnara.backend.poll.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "vote_statistics",
         uniqueConstraints = @UniqueConstraint(columnNames = {"poll_id", "option_id"}))
 @Getter

--- a/backend/src/main/java/com/tamnara/backend/poll/repository/PollOptionRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/repository/PollOptionRepository.java
@@ -6,7 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface PollOptionRepository extends JpaRepository<PollOption, Long> {
-
-    // 특정 Poll에 속한 모든 선택지
     List<PollOption> findByPollId(Long pollId);
 }

--- a/backend/src/main/java/com/tamnara/backend/poll/repository/PollRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/repository/PollRepository.java
@@ -8,9 +8,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PollRepository extends JpaRepository<Poll, Long> {
-    // 상태로 투표 필터링
     List<Poll> findByState(PollState state);
-
-    // 종료일 이전의 투표만 찾기
     List<Poll> findByEndAtAfter(LocalDateTime now);
 }

--- a/backend/src/test/java/com/tamnara/backend/poll/domain/PollTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/domain/PollTest.java
@@ -1,4 +1,0 @@
-package com.tamnara.backend.poll.domain;
-
-public class PollTest {
-}

--- a/backend/src/test/java/com/tamnara/backend/poll/repository/PollOptionRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/repository/PollOptionRepositoryTest.java
@@ -23,11 +23,8 @@ class PollOptionRepositoryTest {
     @MockBean
     private JPAQueryFactory jpaQueryFactory; // NewsSearchRepositoryImpl 로딩 시 필요
 
-    @Autowired
-    private PollRepository pollRepository;
-
-    @Autowired
-    private PollOptionRepository pollOptionRepository;
+    @Autowired private PollRepository pollRepository;
+    @Autowired private PollOptionRepository pollOptionRepository;
 
     @Test
     @DisplayName("PollOption을 저장하고 PollId로 조회한다")

--- a/backend/src/test/java/com/tamnara/backend/poll/repository/PollOptionRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/repository/PollOptionRepositoryTest.java
@@ -1,0 +1,70 @@
+package com.tamnara.backend.poll.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tamnara.backend.poll.domain.Poll;
+import com.tamnara.backend.poll.domain.PollOption;
+import com.tamnara.backend.poll.domain.PollState;
+import com.tamnara.backend.poll.util.PollTestBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PollOptionRepositoryTest {
+    @MockBean
+    private JPAQueryFactory jpaQueryFactory; // NewsSearchRepositoryImpl 로딩 시 필요
+
+    @Autowired
+    private PollRepository pollRepository;
+
+    @Autowired
+    private PollOptionRepository pollOptionRepository;
+
+    @Test
+    @DisplayName("PollOption을 저장하고 PollId로 조회한다")
+    void saveAndFindByPollId() {
+        // given
+        Poll poll = PollTestBuilder.build(
+                "투표 제목",
+                1,
+                2,
+                LocalDateTime.now().minusDays(1),
+                LocalDateTime.now().plusDays(1),
+                PollState.PUBLISHED
+        );
+        Poll savedPoll = pollRepository.save(poll);
+
+        PollOption option1 = PollOption.builder()
+                .title("옵션 1")
+                .imageUrl("https://example.com/img1.png")
+                .sortOrder(0)
+                .poll(savedPoll)
+                .build();
+
+        PollOption option2 = PollOption.builder()
+                .title("옵션 2")
+                .imageUrl("https://example.com/img2.png")
+                .sortOrder(1)
+                .poll(savedPoll)
+                .build();
+
+        pollOptionRepository.saveAll(List.of(option1, option2));
+
+        // when
+        List<PollOption> result = pollOptionRepository.findByPollId(savedPoll.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getTitle()).isEqualTo("옵션 1");
+        assertThat(result.get(1).getPoll().getId()).isEqualTo(savedPoll.getId());
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/repository/PollRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/repository/PollRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.tamnara.backend.poll.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tamnara.backend.poll.domain.Poll;
+import com.tamnara.backend.poll.domain.PollState;
+import com.tamnara.backend.poll.util.PollTestBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class PollRepositoryTest {
+    @MockBean
+    private JPAQueryFactory jpaQueryFactory;
+
+    @Autowired
+    private PollRepository pollRepository;
+
+    @Test
+    @DisplayName("Poll 저장 및 조회에 성공한다")
+    void saveAndFindPoll() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Poll poll = PollTestBuilder.build(
+                "테스트 투표",
+                1,
+                2,
+                now.minusDays(1),
+                now.plusDays(3),
+                PollState.PUBLISHED
+        );
+
+        // when
+        Poll saved = pollRepository.save(poll);
+        Poll found = pollRepository.findById(saved.getId()).orElseThrow();
+
+        // then
+        assertThat(found.getTitle()).isEqualTo("테스트 투표");
+        assertThat(found.getState()).isEqualTo(PollState.PUBLISHED);
+        assertThat(found.getMinChoices()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("state==PUBLISHED인 투표 조회에 성공한다")
+    void findByState() {
+        // given
+        Poll openPoll = PollTestBuilder.defaultPoll();
+        pollRepository.save(openPoll);
+
+        // when
+        List<Poll> result = pollRepository.findByState(PollState.PUBLISHED);
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).getState()).isEqualTo(PollState.PUBLISHED);
+    }
+
+    @Test
+    @DisplayName("종료 시간이 현재 이후인 투표 조회에 성공한다")
+    void findByEndAtAfter() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        Poll poll = PollTestBuilder.defaultPoll();
+        pollRepository.save(poll);
+
+        // when
+        List<Poll> result = pollRepository.findByEndAtAfter(now);
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).getEndAt()).isAfter(now);
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/repository/PollRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/repository/PollRepositoryTest.java
@@ -20,10 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class PollRepositoryTest {
     @MockBean
-    private JPAQueryFactory jpaQueryFactory;
+    private JPAQueryFactory jpaQueryFactory; // NewsSearchRepositoryImpl 로딩 시 필요
 
-    @Autowired
-    private PollRepository pollRepository;
+    @Autowired private PollRepository pollRepository;
 
     @Test
     @DisplayName("Poll 저장 및 조회에 성공한다")

--- a/backend/src/test/java/com/tamnara/backend/poll/repository/VoteRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/repository/VoteRepositoryTest.java
@@ -1,0 +1,4 @@
+package com.tamnara.backend.poll.repository;
+
+public class VoteRepositoryTest {
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/repository/VoteRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/repository/VoteRepositoryTest.java
@@ -1,4 +1,88 @@
 package com.tamnara.backend.poll.repository;
 
-public class VoteRepositoryTest {
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tamnara.backend.poll.domain.*;
+import com.tamnara.backend.poll.util.PollOptionTestBuilder;
+import com.tamnara.backend.poll.util.VoteTestBuilder;
+import com.tamnara.backend.user.domain.User;
+import com.tamnara.backend.user.repository.UserRepository;
+import com.tamnara.backend.poll.util.PollTestBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.List;
+
+import static com.tamnara.backend.utils.CreateUserUtils.createActiveUser;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class VoteRepositoryTest {
+    @MockBean
+    private JPAQueryFactory jpaQueryFactory; // NewsSearchRepositoryImpl 로딩 시 필요
+
+    @Autowired private PollRepository pollRepository;
+    @Autowired private PollOptionRepository pollOptionRepository;
+    @Autowired private VoteRepository voteRepository;
+    @Autowired private UserRepository userRepository;
+
+    private User savedUser;
+
+    @BeforeEach
+    void setup() {
+        this.savedUser = userRepository.save(createActiveUser(
+                "test@user.com", "tester", "KAKAO", "123"));
+    }
+
+    @Test
+    @DisplayName("UserId와 PollId 조합으로 Vote 저장 및 조회에 성공한다")
+    void saveVoteAndFindByUserAndPoll() {
+        // given
+        Poll poll = pollRepository.save(PollTestBuilder.defaultPoll());
+        PollOption option = pollOptionRepository.save(PollOptionTestBuilder.defaultOption(poll));
+        Vote vote = voteRepository.save(VoteTestBuilder.build(savedUser, poll, option));
+
+        // when
+        List<Vote> result = voteRepository.findByUserIdAndPollId(savedUser.getId(), poll.getId());
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getUser().getUsername()).isEqualTo("tester");
+    }
+
+    @Test
+    @DisplayName("Poll ID로 전체 투표 기록 조회에 성공한다")
+    void findByPollId() {
+        // given
+        Poll poll = pollRepository.save(PollTestBuilder.defaultPoll());
+        PollOption option = pollOptionRepository.save(PollOptionTestBuilder.defaultOption(poll));
+        Vote vote = voteRepository.save(VoteTestBuilder.build(savedUser, poll, option));
+
+        // when
+        List<Vote> votes = voteRepository.findByPollId(poll.getId());
+
+        // then
+        assertThat(votes).hasSize(1);
+        assertThat(votes.get(0).getPoll().getId()).isEqualTo(poll.getId());
+    }
+
+    @Test
+    @DisplayName("PollID와 OptionID 조합으로 투표 수 조회에 성공한다")
+    void countVotesByPollAndOption() {
+        // given
+        Poll poll = pollRepository.save(PollTestBuilder.defaultPoll());
+        PollOption option = pollOptionRepository.save(PollOptionTestBuilder.defaultOption(poll));
+        Vote vote = voteRepository.save(VoteTestBuilder.build(savedUser, poll, option));
+
+        // when
+        long count = voteRepository.countByPollIdAndOptionId(poll.getId(), option.getId());
+
+        // then
+        assertThat(count).isEqualTo(1);
+    }
 }

--- a/backend/src/test/java/com/tamnara/backend/poll/repository/VoteRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/repository/VoteRepositoryTest.java
@@ -17,7 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.List;
 
-import static com.tamnara.backend.utils.CreateUserUtils.createActiveUser;
+import static com.tamnara.backend.global.util.CreateUserUtil.createActiveUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest

--- a/backend/src/test/java/com/tamnara/backend/poll/repository/VoteStatisticsRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/repository/VoteStatisticsRepositoryTest.java
@@ -1,0 +1,4 @@
+package com.tamnara.backend.poll.repository;
+
+public class VoteStatisticsRepositoryTest {
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/repository/VoteStatisticsRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/repository/VoteStatisticsRepositoryTest.java
@@ -1,4 +1,78 @@
 package com.tamnara.backend.poll.repository;
 
-public class VoteStatisticsRepositoryTest {
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tamnara.backend.poll.domain.*;
+import com.tamnara.backend.poll.util.PollOptionTestBuilder;
+import com.tamnara.backend.poll.util.PollTestBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class VoteStatisticsRepositoryTest {
+
+    @MockBean
+    private JPAQueryFactory jpaQueryFactory;
+
+    @Autowired private PollRepository pollRepository;
+    @Autowired private PollOptionRepository pollOptionRepository;
+    @Autowired private VoteStatisticsRepository voteStatisticsRepository;
+
+    @Test
+    @DisplayName("기본 통계 객체 생성과 저장, 조회에 성공한다")
+    void saveAndFindByPollId() {
+        // given
+        Poll poll = pollRepository.save(PollTestBuilder.defaultPoll());
+        PollOption option = pollOptionRepository.save(PollOptionTestBuilder.defaultOption(poll));
+        VoteStatistics stat = voteStatisticsRepository.save(VoteStatistics.zero(poll, option));
+
+        // when
+        List<VoteStatistics> result = voteStatisticsRepository.findByPollId(poll.getId());
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCount()).isEqualTo(0L);
+        assertThat(result.get(0).getPoll().getId()).isEqualTo(poll.getId());
+    }
+
+    @Test
+    @DisplayName("PollId + OptionId 조합으로 VoteStatistics 단건 조회에 성공한다")
+    void findByPollIdAndOptionId() {
+        // given
+        Poll poll = pollRepository.save(PollTestBuilder.defaultPoll());
+        PollOption option = pollOptionRepository.save(PollOptionTestBuilder.defaultOption(poll));
+        voteStatisticsRepository.save(VoteStatistics.zero(poll, option));
+
+        // when
+        Optional<VoteStatistics> result = voteStatisticsRepository.findByPollIdAndOptionId(poll.getId(), option.getId());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getOption().getId()).isEqualTo(option.getId());
+    }
+
+    @Test
+    @DisplayName("PollId + OptionId 중복 저장 시 예외가 발생한다")
+    void duplicatePollAndOptionThrowsException() {
+        // given
+        Poll poll = pollRepository.save(PollTestBuilder.defaultPoll());
+        PollOption option = pollOptionRepository.save(PollOptionTestBuilder.defaultOption(poll));
+        voteStatisticsRepository.save(VoteStatistics.zero(poll, option));
+
+        // when & then
+        VoteStatistics duplicate = VoteStatistics.zero(poll, option);
+        org.junit.jupiter.api.Assertions.assertThrows(
+                org.springframework.dao.DataIntegrityViolationException.class,
+                () -> voteStatisticsRepository.saveAndFlush(duplicate)
+        );
+    }
 }

--- a/backend/src/test/java/com/tamnara/backend/poll/util/PollOptionTestBuilder.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/util/PollOptionTestBuilder.java
@@ -1,0 +1,20 @@
+package com.tamnara.backend.poll.util;
+
+import com.tamnara.backend.poll.domain.Poll;
+import com.tamnara.backend.poll.domain.PollOption;
+
+public class PollOptionTestBuilder {
+
+    public static PollOption build(String title, int sortOrder, String imageUrl, Poll poll) {
+        return PollOption.builder()
+                .title(title)
+                .imageUrl(imageUrl)
+                .sortOrder(sortOrder)
+                .poll(poll)
+                .build();
+    }
+
+    public static PollOption defaultOption(Poll poll) {
+        return build("기본 옵션", 0, "https://example.com/image.png", poll);
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/util/PollTestBuilder.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/util/PollTestBuilder.java
@@ -1,0 +1,4 @@
+package com.tamnara.backend.poll.util;
+
+public class PollTestBuilder {
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/util/PollTestBuilder.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/util/PollTestBuilder.java
@@ -1,4 +1,39 @@
 package com.tamnara.backend.poll.util;
 
+import com.tamnara.backend.poll.domain.Poll;
+import com.tamnara.backend.poll.domain.PollState;
+
+import java.time.LocalDateTime;
+
 public class PollTestBuilder {
+
+    public static Poll build(
+            String title,
+            int minChoices,
+            int maxChoices,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            PollState state
+    ) {
+        return Poll.builder()
+                .title(title)
+                .minChoices(minChoices)
+                .maxChoices(maxChoices)
+                .startAt(startAt)
+                .endAt(endAt)
+                .state(state)
+                .build();
+    }
+
+    public static Poll defaultPoll() {
+        LocalDateTime now = LocalDateTime.now();
+        return build(
+                "테스트용 기본 투표",
+                1,
+                2,
+                now.minusDays(1),
+                now.plusDays(3),
+                PollState.PUBLISHED
+        );
+    }
 }

--- a/backend/src/test/java/com/tamnara/backend/poll/util/VoteTestBuilder.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/util/VoteTestBuilder.java
@@ -1,4 +1,21 @@
 package com.tamnara.backend.poll.util;
 
+import com.tamnara.backend.poll.domain.Poll;
+import com.tamnara.backend.poll.domain.PollOption;
+import com.tamnara.backend.poll.domain.Vote;
+import com.tamnara.backend.user.domain.User;
+
+import java.time.LocalDateTime;
+
 public class VoteTestBuilder {
+
+    public static Vote build(User user, Poll poll, PollOption option) {
+        return Vote.builder()
+                .user(user)
+                .poll(poll)
+                .option(option)
+                .createdAt(LocalDateTime.now())
+                .votedAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/backend/src/test/java/com/tamnara/backend/poll/util/VoteTestBuilder.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/util/VoteTestBuilder.java
@@ -1,0 +1,4 @@
+package com.tamnara.backend.poll.util;
+
+public class VoteTestBuilder {
+}

--- a/backend/src/test/java/com/tamnara/backend/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/user/repository/UserRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.tamnara.backend.user.repository;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tamnara.backend.user.domain.Role;
 import com.tamnara.backend.user.domain.State;
 import com.tamnara.backend.user.domain.User;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
@@ -19,6 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class UserRepositoryTest {
+
+    @MockBean
+    private JPAQueryFactory jpaQueryFactory;
 
     @Autowired
     private UserRepository userRepository;


### PR DESCRIPTION
### 관련 이슈
#198 

---

### 작업 개요
`Poll`, `PollOption`, `Vote`, `VoteStatistics` 엔티티에 대한 Repository 단위 테스트를 작성했습니다.  
각 Repository의 기본 CRUD 및 쿼리 메서드 동작을 검증합니다.

---

### 주요 변경 사항

1. `PollRepositoryTest`
- Poll 저장 및 조회 테스트
- `findByState(PollState)` 동작 확인
- `findByEndAtAfter(LocalDateTime)` 동작 확인

2. `PollOptionRepositoryTest`
- PollOption 저장 및 조회 테스트
- `findByPollId(Long)`로 옵션 리스트 조회 확인

3. `VoteRepositoryTest`
- `findByUserIdAndPollId()` 로 유저의 투표 조회
- `findByPollId()`로 투표 목록 조회
- `countByPollIdAndOptionId()`로 특정 옵션에 대한 투표 수 조회
- `JPAQueryFactory` 의존성 문제로 `@MockBean` 처리

4. `VoteStatisticsRepositoryTest`
- `VoteStatistics.zero()` 저장 테스트
- `findByPollId()`, `findByPollIdAndOptionId()` 쿼리 테스트
- 복합 유니크 제약(`poll_id + option_id`) 중복 저장 시 예외 검증
- 테스트 환경에서 `@CreatedDate` 반영을 위해 `TestJpaAuditingConfig` 추가

---

### 기타 변경
- 테스트 편의성을 위한 Builder 클래스 추가
  - `PollTestBuilder`
  - `PollOptionTestBuilder`
  - `VoteTestBuilder`
- 유저 중복 방지를 위한 providerId 유니크 처리

---

### 참고 사항
- 각 테스트는 실제 MySQL 설정을 사용하는 `@AutoConfigureTestDatabase(replace = NONE)` 방식으로 작성
- 테스트 context에서 `@EnableJpaAuditing`이 적용되지 않아, 별도 `@Import(TestJpaAuditingConfig.class)` 방식으로 해결

---

### 테스트 완료

<img width="1036" alt="image" src="https://github.com/user-attachments/assets/b003b32d-2cf9-4160-bf3f-73f436a81c29" />
