### PR TITLE
feat: 뉴스 기능에 핫이슈 생성 및 오래된 뉴스 삭제 스케줄링 메서드 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/config/SchedulingConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.tamnara.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/backend/src/main/java/com/tamnara/backend/news/constant/NewsServiceConstant.java
+++ b/backend/src/main/java/com/tamnara/backend/news/constant/NewsServiceConstant.java
@@ -7,6 +7,7 @@ public final class NewsServiceConstant {
     public static final Integer TAGS_MIN_SIZE = 1;
     public static final Integer TAGS_MAX_SIZE = 6;
     public static final Integer STATISTICS_AI_SEARCH_CNT = 10;
+    public static final Integer HOTISSUE_CREATE_CNT = 3;
     public static final Integer NEWS_CREATE_DAYS = 30;
     public static final Integer NEWS_UPDATE_HOURS = 24;
     public static final Integer NEWS_DELETE_DAYS = 90;

--- a/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/com/tamnara/backend/news/controller/NewsController.java
@@ -205,7 +205,7 @@ public class NewsController {
 
             Long userId = userDetails.getUser().getId();
 
-            NewsDetailDTO newsDetailDTO = newsService.update(newsId, userId);
+            NewsDetailDTO newsDetailDTO = newsService.update(newsId, userId, false);
             if (newsDetailDTO == null) {
                 return ResponseEntity.noContent().build();
             }

--- a/backend/src/main/java/com/tamnara/backend/news/dto/request/AIHotissueRequest.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/request/AIHotissueRequest.java
@@ -1,0 +1,10 @@
+package com.tamnara.backend.news.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AIHotissueRequest {
+    Integer num;
+}

--- a/backend/src/main/java/com/tamnara/backend/news/dto/response/AIHotissueResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/response/AIHotissueResponse.java
@@ -1,0 +1,12 @@
+package com.tamnara.backend.news.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AIHotissueResponse {
+    private List<String> keywords;
+}

--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
@@ -46,6 +46,10 @@ public interface NewsRepository extends JpaRepository<News, Long>, NewsSearchRep
     Optional<News> findNewsByExactlyMatchingTags(@Param("keywords") List<String> keywords, @Param("size") Integer size);
 
     @Modifying
+    @Query("UPDATE News n SET n.isHotissue = :isHotissue WHERE n.id = :newsId")
+    void updateIsHotissue(@Param("newsId") Long newsId, @Param("isHotissue") boolean isHotissue);
+
+    @Modifying
     @Query("UPDATE News n SET n.viewCount = n.viewCount + 1 WHERE n.id = :newsId")
     void increaseViewCount(@Param("newsId") Long newsId);
 

--- a/backend/src/main/java/com/tamnara/backend/news/service/AIService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/AIService.java
@@ -2,6 +2,7 @@ package com.tamnara.backend.news.service;
 
 import com.tamnara.backend.global.dto.WrappedDTO;
 import com.tamnara.backend.news.dto.TimelineCardDTO;
+import com.tamnara.backend.news.dto.response.AIHotissueResponse;
 import com.tamnara.backend.news.dto.response.AINewsResponse;
 
 import java.time.LocalDate;
@@ -10,4 +11,5 @@ import java.util.List;
 public interface AIService {
     WrappedDTO<AINewsResponse> createAINews(List<String> keywords, LocalDate startAt, LocalDate endAt);
     List<TimelineCardDTO> mergeTimelineCards(List<TimelineCardDTO> timeline);
+    WrappedDTO<AIHotissueResponse> createAIHotissueKeywords();
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerService.java
@@ -1,0 +1,5 @@
+package com.tamnara.backend.news.service;
+
+public interface NewsSchedulerService {
+    void createHotissueNews();
+}

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerService.java
@@ -2,4 +2,5 @@ package com.tamnara.backend.news.service;
 
 public interface NewsSchedulerService {
     void createHotissueNews();
+    void deleteOldNewsAndOrphanTags();
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerServiceImpl.java
@@ -27,4 +27,17 @@ public class NewsSchedulerServiceImpl implements NewsSchedulerService {
             log.error("[ERROR] 핫이슈 뉴스 생성 중 오류 발생: {}", e.getMessage(), e);
         }
     }
+
+    @Override
+    @Async
+    @Scheduled(cron = "0 0 9 * * *")
+    public void deleteOldNewsAndOrphanTags() {
+        try {
+            log.info("[INFO] 오래된 뉴스 삭제 및 고아 태그 삭제 시작");
+            newsService.deleteOldNewsAndOrphanTags();
+            log.info("[INFO] 오래된 뉴스 삭제 및 고아 태그 삭제 완료");
+        } catch (Exception e) {
+            log.error("[ERROR] 오래된 뉴스 삭제 및 고아 태그 삭제 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerServiceImpl.java
@@ -1,0 +1,30 @@
+package com.tamnara.backend.news.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class NewsSchedulerServiceImpl implements NewsSchedulerService {
+
+    private final NewsService newsService;
+
+    public NewsSchedulerServiceImpl(NewsService newsService) {
+        this.newsService = newsService;
+    }
+
+    @Override
+    @Async
+    @Scheduled(cron = "0 0 9 * * *")
+    public void createHotissueNews() {
+        try {
+            log.info("[INFO] 핫이슈 뉴스 생성 시작");
+            newsService.createHotissueNews();
+            log.info("[INFO] 핫이슈 뉴스 생성 완료");
+        } catch (Exception e) {
+            log.error("[ERROR] 핫이슈 뉴스 생성 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsSchedulerServiceImpl.java
@@ -21,8 +21,12 @@ public class NewsSchedulerServiceImpl implements NewsSchedulerService {
     public void createHotissueNews() {
         try {
             log.info("[INFO] 핫이슈 뉴스 생성 시작");
+            Long start = System.currentTimeMillis();
+
             newsService.createHotissueNews();
-            log.info("[INFO] 핫이슈 뉴스 생성 완료");
+
+            Long end = System.currentTimeMillis();
+            log.info("[INFO] 핫이슈 뉴스 생성 완료: {} ms", (end - start));
         } catch (Exception e) {
             log.error("[ERROR] 핫이슈 뉴스 생성 중 오류 발생: {}", e.getMessage(), e);
         }
@@ -34,8 +38,12 @@ public class NewsSchedulerServiceImpl implements NewsSchedulerService {
     public void deleteOldNewsAndOrphanTags() {
         try {
             log.info("[INFO] 오래된 뉴스 삭제 및 고아 태그 삭제 시작");
+            Long start = System.currentTimeMillis();
+
             newsService.deleteOldNewsAndOrphanTags();
-            log.info("[INFO] 오래된 뉴스 삭제 및 고아 태그 삭제 완료");
+
+            Long end = System.currentTimeMillis();
+            log.info("[INFO] 오래된 뉴스 삭제 및 고아 태그 삭제 완료: {}", (end - start));
         } catch (Exception e) {
             log.error("[ERROR] 오래된 뉴스 삭제 및 고아 태그 삭제 중 오류 발생: {}", e.getMessage(), e);
         }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
@@ -15,6 +15,6 @@ public interface NewsService {
     NewsListResponse getSearchNewsCardPage(Long userId, List<String> tags, Integer offset);
     NewsDetailDTO getNewsDetail(Long newsId, Long userId);
     NewsDetailDTO save(Long userId, boolean isHotissue, NewsCreateRequest req);
-    NewsDetailDTO update(Long newsId, Long userId);
+    NewsDetailDTO update(Long newsId, Long userId, boolean isHotissue);
     void delete(Long newsId, Long userId);
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
@@ -19,4 +19,5 @@ public interface NewsService {
     void delete(Long newsId, Long userId);
 
     void createHotissueNews();
+    void deleteOldNewsAndOrphanTags();
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsService.java
@@ -17,4 +17,6 @@ public interface NewsService {
     NewsDetailDTO save(Long userId, boolean isHotissue, NewsCreateRequest req);
     NewsDetailDTO update(Long newsId, Long userId, boolean isHotissue);
     void delete(Long newsId, Long userId);
+
+    void createHotissueNews();
 }

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -211,8 +211,11 @@ public class NewsServiceImpl implements NewsService {
     @Override
     @Transactional
     public NewsDetailDTO save(Long userId, boolean isHotissue, NewsCreateRequest req) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
+        User user = null;
+        if (!isHotissue) {
+            user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
+        }
 
         // 0. 뉴스 생성 키워드 목록과 기존 뉴스의 태그 목록이 일치할 경우, 기존 뉴스를 업데이트한다.
         Optional<News> optionalNews = newsRepository.findNewsByExactlyMatchingTags(req.getKeywords(), req.getKeywords().size());
@@ -307,10 +310,12 @@ public class NewsServiceImpl implements NewsService {
         });
 
         // 6. 생성된 뉴스에 대해 북마크 설정한다.
-        Bookmark bookmark = new Bookmark();
-        bookmark.setUser(user);
-        bookmark.setNews(news);
-        bookmarkRepository.save(bookmark);
+        if (!isHotissue) {
+            Bookmark bookmark = new Bookmark();
+            bookmark.setUser(user);
+            bookmark.setNews(news);
+            bookmarkRepository.save(bookmark);
+        }
 
         // 7. 뉴스의 상세 페이지 데이터를 반환한다.
         return new NewsDetailDTO(

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -487,6 +487,11 @@ public class NewsServiceImpl implements NewsService {
         WrappedDTO<AIHotissueResponse> res = aiService.createAIHotissueKeywords();
         aiHotissueResponse = res.getData();
 
+        List<News> previousHotissuesList = newsRepository.findAllByIsHotissueTrueOrderByIdAsc(Pageable.unpaged()).getContent();
+        for (News news : previousHotissuesList) {
+            newsRepository.updateIsHotissue(news.getId(), false);
+        }
+
         for (String keyword : aiHotissueResponse.getKeywords()) {
             NewsCreateRequest req = new NewsCreateRequest(List.of(keyword));
             save(null, true, req);

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -175,6 +175,7 @@ public class NewsServiceImpl implements NewsService {
     }
 
     @Override
+    @Transactional
     public NewsDetailDTO getNewsDetail(Long newsId, Long userId) {
         News news = newsRepository.findById(newsId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.NEWS_NOT_FOUND));
@@ -194,8 +195,7 @@ public class NewsServiceImpl implements NewsService {
         StatisticsDTO statistics = getStatisticsDTO(news);
         boolean bookmarked = user.map(u -> getBookmarked(u, news)).orElse(false);
 
-        news.setViewCount(news.getViewCount() + 1);
-        newsRepository.save(news);
+        newsRepository.increaseViewCount(news.getId());
 
         return new NewsDetailDTO(
                 news.getId(),

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -20,6 +20,7 @@ import com.tamnara.backend.news.dto.NewsDetailDTO;
 import com.tamnara.backend.news.dto.StatisticsDTO;
 import com.tamnara.backend.news.dto.TimelineCardDTO;
 import com.tamnara.backend.news.dto.request.NewsCreateRequest;
+import com.tamnara.backend.news.dto.response.AIHotissueResponse;
 import com.tamnara.backend.news.dto.response.AINewsResponse;
 import com.tamnara.backend.news.dto.response.HotissueNewsListResponse;
 import com.tamnara.backend.news.dto.response.NewsListResponse;
@@ -477,6 +478,19 @@ public class NewsServiceImpl implements NewsService {
         }
 
         newsRepository.delete(news);
+    }
+
+    @Override
+    @Transactional
+    public void createHotissueNews() {
+        AIHotissueResponse aiHotissueResponse;
+        WrappedDTO<AIHotissueResponse> res = aiService.createAIHotissueKeywords();
+        aiHotissueResponse = res.getData();
+
+        for (String keyword : aiHotissueResponse.getKeywords()) {
+            NewsCreateRequest req = new NewsCreateRequest(List.of(keyword));
+            save(null, true, req);
+        }
     }
 
 

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -498,6 +498,12 @@ public class NewsServiceImpl implements NewsService {
         }
     }
 
+    @Override
+    public void deleteOldNewsAndOrphanTags() {
+        newsRepository.deleteAllOlderThan(LocalDateTime.now().minusDays(NewsServiceConstant.NEWS_DELETE_DAYS));
+        tagRepository.deleteAllOrphan();
+    }
+
 
     /*
         함수 편의용

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -221,7 +221,7 @@ public class NewsServiceImpl implements NewsService {
         Optional<News> optionalNews = newsRepository.findNewsByExactlyMatchingTags(req.getKeywords(), req.getKeywords().size());
         if (optionalNews.isPresent()) {
             Long newsId = optionalNews.get().getId();
-            return update(newsId, userId);
+            return update(newsId, userId, isHotissue);
         }
 
         // 1. 뉴스의 여론 통계 생성을 비동기적으로 시작한다.
@@ -331,7 +331,7 @@ public class NewsServiceImpl implements NewsService {
 
     @Override
     @Transactional
-    public NewsDetailDTO update(Long newsId, Long userId) {
+    public NewsDetailDTO update(Long newsId, Long userId, boolean isHotissue) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
 
@@ -399,6 +399,7 @@ public class NewsServiceImpl implements NewsService {
         // 4. 저장
         // 4-1. 뉴스를 저장한다.
         news.setSummary(aiNewsResponse.getSummary());
+        news.setIsHotissue(isHotissue);
 
         news.setUpdateCount(news.getUpdateCount() + 1);
         if (statistics != null) {

--- a/backend/src/test/java/com/tamnara/backend/news/controller/NewsControllerTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/controller/NewsControllerTest.java
@@ -754,7 +754,7 @@ public class NewsControllerTest {
         // given
         Long newsId = 1L;
         NewsDetailDTO response = createNewsDetailDTO(newsId, true);
-        given(newsService.update(eq(newsId), eq(USER_ID))).willReturn(response);
+        given(newsService.update(eq(newsId), eq(USER_ID), eq(false))).willReturn(response);
 
         // when & then
         mockMvc.perform(patch("/news/{newsId}", newsId))

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
@@ -260,20 +260,33 @@ public class NewsRepositoryTest {
     }
 
     @Test
-    void 뉴스_핫이슈_전환_검증() {
+    void 뉴스_핫이슈_전환_시_수정일자_변경되지_않고_유지_검증() {
         // given
-        News news = createNews("제목", "미리보기 내용", user, category);
-        news.setIsHotissue(true);
-        newsRepository.save(news);
+        News news1 = createNews("제목1", "미리보기 내용1", user, category);
+        news1.setIsHotissue(true);
+        newsRepository.save(news1);
+        LocalDateTime news1UpdatedAt = news1.getUpdatedAt();
+
+        News news2 = createNews("제목2", "미리보기 내용2", user, category);
+        news2.setIsHotissue(false);
+        newsRepository.save(news2);
+        LocalDateTime news2UpdatedAt = news2.getUpdatedAt();
+
+        try { Thread.sleep(1000); } catch (InterruptedException e) {}
 
         // when
-        News findNews = newsRepository.findById(news.getId()).get();
-        findNews.setIsHotissue(false);
-        newsRepository.save(findNews);
+        newsRepository.updateIsHotissue(news1.getId(), false);
+        newsRepository.updateIsHotissue(news2.getId(), true);
+        em.clear();
 
         // then
-        News updatedNews = newsRepository.findById(news.getId()).get();
-        assertFalse(updatedNews.getIsHotissue());
+        News updatedNews1 = newsRepository.findById(news1.getId()).get();
+        assertFalse(updatedNews1.getIsHotissue());
+        assertEquals(news1UpdatedAt.truncatedTo(ChronoUnit.SECONDS), updatedNews1.getUpdatedAt().truncatedTo(ChronoUnit.SECONDS));
+
+        News updatedNews2 = newsRepository.findById(news2.getId()).get();
+        assertTrue(updatedNews2.getIsHotissue());
+        assertEquals(news2UpdatedAt.truncatedTo(ChronoUnit.SECONDS), updatedNews2.getUpdatedAt().truncatedTo(ChronoUnit.SECONDS));
     }
 
     @Test

--- a/backend/src/test/java/com/tamnara/backend/news/service/NewsSchedulerServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/service/NewsSchedulerServiceImplTest.java
@@ -1,0 +1,27 @@
+package com.tamnara.backend.news.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class NewsSchedulerServiceImplTest {
+
+    @Mock private NewsService newsService;
+
+    @InjectMocks private NewsSchedulerServiceImpl newsSchedulerService;
+
+    @Test
+    void 핫이슈_뉴스_생성_검증() {
+        // when
+        newsSchedulerService.createHotissueNews();
+
+        // then
+        verify(newsService, times(1)).createHotissueNews();
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/news/service/NewsSchedulerServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/service/NewsSchedulerServiceImplTest.java
@@ -24,4 +24,13 @@ public class NewsSchedulerServiceImplTest {
         // then
         verify(newsService, times(1)).createHotissueNews();
     }
+
+    @Test
+    void 오래된_뉴스_및_고아_태그_삭제_검증() {
+        // when
+        newsSchedulerService.deleteOldNewsAndOrphanTags();
+
+        // then
+        verify(newsService, times(1)).deleteOldNewsAndOrphanTags();
+    }
 }

--- a/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
@@ -1046,13 +1046,14 @@ class NewsServiceImplTest {
     }
 
     @Test
-    void 핫이슈_생성_시_기존_핫이슈_뉴스들은_일반_뉴스로_전환_검증() {// given
+    void 핫이슈_생성_시_기존_핫이슈_뉴스들은_일반_뉴스로_전환_검증() {
+        // given
         AIHotissueResponse aiHotissueResponse = new AIHotissueResponse(List.of());
         WrappedDTO<AIHotissueResponse> WrappedResponse = new WrappedDTO<>(true, "메시지", aiHotissueResponse);
 
         News news1 = createNews(1L, "제목1", "미리보기 내용2", true, user, ktb);
         News news2 = createNews(2L, "제목2", "미리보기 내용2", true, user, economy);
-        News news3 = createNews(2L, "제목3", "미리보기 내용3", true, user, sports);
+        News news3 = createNews(3L, "제목3", "미리보기 내용3", true, user, sports);
         Page<News> previousNewsPage = new PageImpl<>(Arrays.asList(news1, news2, news3));
 
         when(aiService.createAIHotissueKeywords()).thenReturn(WrappedResponse);
@@ -1062,9 +1063,8 @@ class NewsServiceImplTest {
         newsServiceImpl.createHotissueNews();
 
         // then
-        verify(newsRepository, times(3)).save(any(News.class));
-        assertFalse(news1.getIsHotissue());
-        assertFalse(news2.getIsHotissue());
-        assertFalse(news3.getIsHotissue());
+        verify(newsRepository).updateIsHotissue(news1.getId(), false);
+        verify(newsRepository).updateIsHotissue(news2.getId(), false);
+        verify(newsRepository).updateIsHotissue(news3.getId(), false);
     }
 }

--- a/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
@@ -16,6 +16,7 @@ import com.tamnara.backend.news.dto.NewsDetailDTO;
 import com.tamnara.backend.news.dto.StatisticsDTO;
 import com.tamnara.backend.news.dto.TimelineCardDTO;
 import com.tamnara.backend.news.dto.request.NewsCreateRequest;
+import com.tamnara.backend.news.dto.response.AIHotissueResponse;
 import com.tamnara.backend.news.dto.response.AINewsResponse;
 import com.tamnara.backend.news.dto.response.HotissueNewsListResponse;
 import com.tamnara.backend.news.dto.response.NewsListResponse;
@@ -58,11 +59,15 @@ import java.util.concurrent.CompletableFuture;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -832,5 +837,208 @@ class NewsServiceImplTest {
         // then
         assertEquals(HttpStatus.CONFLICT, exception.getStatusCode());
         assertEquals(NewsResponseMessage.NEWS_UPDATE_CONFLICT, exception.getReason());
+    }
+
+    @Test
+    void 핫이슈_뉴스_생성_검증() {
+        // given
+        List<String> keywords = List.of("키워드1", "키워드2", "키워드3");
+        AIHotissueResponse aiHotissueResponse = new AIHotissueResponse(keywords);
+        WrappedDTO<AIHotissueResponse> WrappedResponse = new WrappedDTO<>(true, "메시지", aiHotissueResponse);
+
+        List<TimelineCardDTO> dayCardDTOs = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            LocalDate localDate = LocalDate.now().minusDays(i);
+
+            TimelineCardDTO dayCardDTO = new TimelineCardDTO(
+                    "제목",
+                    "내용",
+                    List.of("source1", "source2"),
+                    TimelineCardType.DAY.toString(),
+                    localDate,
+                    localDate
+            );
+
+            dayCardDTOs.add(dayCardDTO);
+        }
+
+        WrappedDTO<AINewsResponse> createAiNewsResponse = new WrappedDTO<>(
+                true,
+                "메시지",
+                new AINewsResponse(
+                        "제목",
+                        "미리보기 내용",
+                        "이미지",
+                        CategoryType.SPORTS.toString(),
+                        dayCardDTOs
+                )
+        );
+
+        TimelineCardDTO weekCardDTO = new TimelineCardDTO(
+                "제목",
+                "내용",
+                List.of("source1", "source2"),
+                TimelineCardType.WEEK.toString(),
+                dayCardDTOs.getLast().getStartAt(),
+                dayCardDTOs.getFirst().getStartAt()
+        );
+
+        WrappedDTO<StatisticsDTO> statisticsDTO = new WrappedDTO<>(
+                true,
+                "메시지",
+                new StatisticsDTO(
+                        10,
+                        20,
+                        70
+                )
+        );
+
+        Tag tag = new Tag();
+        tag.setId(1L);
+        tag.setName("태그명");
+
+        when(aiService.createAIHotissueKeywords()).thenReturn(WrappedResponse);
+        when(newsRepository.findNewsByExactlyMatchingTags(List.of(keywords.get(0)), 1)).thenReturn(Optional.empty());
+        when(newsRepository.findNewsByExactlyMatchingTags(List.of(keywords.get(1)), 1)).thenReturn(Optional.empty());
+        when(newsRepository.findNewsByExactlyMatchingTags(List.of(keywords.get(2)), 1)).thenReturn(Optional.empty());
+
+        LocalDate localDate = LocalDate.now();
+        when(aiService.createAINews(List.of(keywords.get(0)), localDate.minusDays(NewsServiceConstant.NEWS_CREATE_DAYS), localDate)).thenReturn(createAiNewsResponse);
+        when(aiService.createAINews(List.of(keywords.get(1)), localDate.minusDays(NewsServiceConstant.NEWS_CREATE_DAYS), localDate)).thenReturn(createAiNewsResponse);
+        when(aiService.createAINews(List.of(keywords.get(2)), localDate.minusDays(NewsServiceConstant.NEWS_CREATE_DAYS), localDate)).thenReturn(createAiNewsResponse);
+        when(aiService.mergeTimelineCards(dayCardDTOs)).thenReturn(List.of(weekCardDTO));
+
+        CompletableFuture<WrappedDTO<StatisticsDTO>> statsAiResponse = CompletableFuture.completedFuture(statisticsDTO);
+        when(asyncAiService.getAIStatistics(List.of(keywords.get(0)))).thenReturn(statsAiResponse);
+        when(asyncAiService.getAIStatistics(List.of(keywords.get(1)))).thenReturn(statsAiResponse);
+        when(asyncAiService.getAIStatistics(List.of(keywords.get(2)))).thenReturn(statsAiResponse);
+        when(tagRepository.findByName(any(String.class))).thenReturn(Optional.of(tag));
+
+        // when
+        newsServiceImpl.createHotissueNews();
+
+        // then
+        verify(newsRepository, times(3)).save(any(News.class));
+        verify(timelineCardRepository, atLeastOnce()).save(any(TimelineCard.class));
+        verify(newsImageRepository, times(3)).save(any(NewsImage.class));
+        verify(newsTagRepository, times(3)).save(any(NewsTag.class));
+        verify(asyncAiService, times(3)).getAIStatistics(anyList());
+        verify(aiService, times(3)).createAINews(anyList(), any(LocalDate.class), any(LocalDate.class));
+        verify(aiService, times(3)).mergeTimelineCards(anyList());
+    }
+
+    @Test
+    void 핫이슈_키워드와_태그_목록이_동일한_뉴스는_핫이슈_전환_검증() {
+        // given
+        News news1 = createNews(1L, "제목1", "미리보기 내용2", false, user, ktb);
+        news1.setUpdatedAt(LocalDateTime.now().minusHours(NewsServiceConstant.NEWS_UPDATE_HOURS));
+
+        News news2 = createNews(2L, "제목2", "미리보기 내용2", false, user, economy);
+        news2.setUpdatedAt(LocalDateTime.now());
+
+        NewsImage newsImage = createNewsImage(1L, news1, "url1");
+        NewsTag newsTag = createNewsTag(1L, news1, createTag(1L, "키워드1"));
+
+        TimelineCard weekCard = createTimelineCard(
+                news1,
+                "제목",
+                "내용",
+                List.of("source1", "source2"),
+                TimelineCardType.WEEK.toString(),
+                LocalDate.now().minusDays(13),
+                LocalDate.now().minusDays(7)
+        );
+        List<TimelineCard> timelineCards = List.of(weekCard);
+
+        List<TimelineCardDTO> dayCardDTOs = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            LocalDate localDate = LocalDate.now().minusDays(i);
+
+            TimelineCardDTO dayCardDTO = new TimelineCardDTO(
+                    "제목",
+                    "내용",
+                    List.of("source1", "source2"),
+                    TimelineCardType.DAY.toString(),
+                    localDate,
+                    localDate
+            );
+
+            dayCardDTOs.add(dayCardDTO);
+        }
+
+        WrappedDTO<AINewsResponse> createAiNewsResponse = new WrappedDTO<>(
+                true,
+                "메시지",
+                new AINewsResponse(
+                        "제목",
+                        "미리보기 내용",
+                        "이미지",
+                        CategoryType.SPORTS.toString(),
+                        dayCardDTOs
+                )
+        );
+
+        TimelineCardDTO weekCardDTO = new TimelineCardDTO(
+                "제목",
+                "내용",
+                List.of("source1", "source2"),
+                TimelineCardType.WEEK.toString(),
+                dayCardDTOs.getLast().getStartAt(),
+                dayCardDTOs.getFirst().getStartAt()
+        );
+
+        WrappedDTO<StatisticsDTO> statisticsDTO = new WrappedDTO<>(
+                true,
+                "메시지",
+                new StatisticsDTO(
+                        10,
+                        20,
+                        70
+                )
+        );
+
+        Tag tag = new Tag();
+        tag.setId(1L);
+        tag.setName("태그명");
+
+        List<String> keywords = List.of("키워드1", "키워드2", "키워드3");
+        AIHotissueResponse aiHotissueResponse = new AIHotissueResponse(keywords);
+        WrappedDTO<AIHotissueResponse> WrappedResponse = new WrappedDTO<>(true, "메시지", aiHotissueResponse);
+
+        when(aiService.createAIHotissueKeywords()).thenReturn(WrappedResponse);
+        when(newsRepository.findNewsByExactlyMatchingTags(List.of(keywords.get(0)), 1)).thenReturn(Optional.empty());
+        when(newsRepository.findNewsByExactlyMatchingTags(List.of(keywords.get(1)), 1)).thenReturn(Optional.of(news1));
+        when(newsRepository.findNewsByExactlyMatchingTags(List.of(keywords.get(2)), 1)).thenReturn(Optional.of(news2));
+
+        when(newsRepository.findById(news1.getId())).thenReturn(Optional.of(news1));
+        when(newsRepository.findById(news2.getId())).thenReturn(Optional.of(news2));
+
+        when(timelineCardRepository.findAllByNewsIdOrderByStartAtDesc(news1.getId())).thenReturn(timelineCards);
+        when(newsTagRepository.findByNewsId(news1.getId())).thenReturn(List.of(newsTag));
+        when(newsImageRepository.findByNewsId(news1.getId())).thenReturn(Optional.of(newsImage));
+
+        when(aiService.createAINews(anyList(), any(LocalDate.class), any(LocalDate.class))).thenReturn(createAiNewsResponse);
+        when(aiService.mergeTimelineCards(dayCardDTOs)).thenReturn(List.of(weekCardDTO));
+
+        CompletableFuture<WrappedDTO<StatisticsDTO>> statsAiResponse = CompletableFuture.completedFuture(statisticsDTO);
+        when(asyncAiService.getAIStatistics(anyList())).thenReturn(statsAiResponse);
+        when(tagRepository.findByName(any(String.class))).thenReturn(Optional.of(tag));
+
+        // when
+        newsServiceImpl.createHotissueNews();
+
+        // then
+        verify(userRepository, times(0)).findById(any(Long.class));
+        verify(newsRepository, times(3)).save(any(News.class));
+        verify(newsRepository, times(2)).findById(any(Long.class));
+        verify(timelineCardRepository, atLeastOnce()).save(any(TimelineCard.class));
+        verify(aiService, times(2)).createAINews(anyList(), any(LocalDate.class), any(LocalDate.class));
+        verify(aiService, times(2)).mergeTimelineCards(anyList());
+        verify(asyncAiService, times(2)).getAIStatistics(anyList());
+        verify(newsImageRepository, times(2)).save(any(NewsImage.class));
+        verify(newsTagRepository, times(1)).save(any(NewsTag.class));
+
+        assertTrue(news1.getIsHotissue());
+        assertTrue(news2.getIsHotissue());
     }
 }

--- a/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
@@ -750,7 +750,7 @@ class NewsServiceImplTest {
         when(asyncAiService.getAIStatistics(query)).thenReturn(statsAiResponse);
 
         // when
-        NewsDetailDTO response = newsServiceImpl.update(news.getId(), user.getId());
+        NewsDetailDTO response = newsServiceImpl.update(news.getId(), user.getId(), false);
 
         // then
         assertEquals(createAiNewsResponse.getData().getTitle(), response.getTitle());
@@ -770,7 +770,7 @@ class NewsServiceImplTest {
 
         // when
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
-            newsServiceImpl.update(news.getId(), user.getId());
+            newsServiceImpl.update(news.getId(), user.getId(), false);
         });
 
         // then

--- a/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/service/NewsServiceImplTest.java
@@ -1067,4 +1067,14 @@ class NewsServiceImplTest {
         verify(newsRepository).updateIsHotissue(news2.getId(), false);
         verify(newsRepository).updateIsHotissue(news3.getId(), false);
     }
+
+    @Test
+    void 오래된_뉴스_및_고아_태그_삭제_검증() {
+        // when
+        newsServiceImpl.deleteOldNewsAndOrphanTags();
+
+        // then
+        verify(newsRepository, times(1)).deleteAllOlderThan(any(LocalDateTime.class));
+        verify(tagRepository, times(1)).deleteAllOrphan();
+    }
 }


### PR DESCRIPTION
## 연관된 이슈
closes #237 

<br/>

## 작업 내용
- [x] 핫이슈 뉴스 처리 스케줄링 메서드 추가
- [x] 오래된 뉴스 및 고아 태그 삭제 스케줄링 메서드 추가

<br/>

## 상세 내용
### 핫이슈 뉴스 처리 스케줄링 메서드 추가

1. **생성할 핫이슈 뉴스 개수에 대하여 상수 선언**

```java
public static final Integer HOTISSUE_CREATE_CNT = 3;
```

2. **`NewsRepository`에 핫이슈 업데이트 메서드 추가**

```java
@Modifying
@Query("UPDATE News n SET n.isHotissue = :isHotissue WHERE n.id = :newsId")
void updateIsHotissue(@Param("newsId") Long newsId, @Param("isHotissue") boolean isHotissue);
```

3. **`AIService`에 핫이슈 키워드 생성 요청 메서드 추가**

```java
WrappedDTO<AIHotissueResponse> createAIHotissueKeywords();
```

4. **`NewsService`에 핫이슈 뉴스 생성** 
    - 뉴스 생성 로직 수정: 핫이슈 생성 시 모든 user 필드 null 처리 및 북마크 처리 생략
    - 뉴스 업데이트 로직 수정
        - `isHotissue` 필드를 true로 업데이트
        - 업데이트 기간이 지나지 않았다면 `isHotissue` 필드 외 업데이트 생략

```java
@Override
@Transactional
public void createHotissueNews() {
    // 1. 핫이슈 키워드 목록 생성을 요청한다.
    AIHotissueResponse aiHotissueResponse;
    WrappedDTO<AIHotissueResponse> res = aiService.createAIHotissueKeywords();
    aiHotissueResponse = res.getData();

		// 2. 기존 핫이슈 뉴스들을 일반 뉴스로 전환한다.
    List<News> previousHotissuesList = newsRepository.findAllByIsHotissueTrueOrderByIdAsc(Pageable.unpaged()).getContent();
    for (News news : previousHotissuesList) {
        newsRepository.updateIsHotissue(news.getId(), false);
    }

    // 3. 핫이슈 키워드 목록을 차례대로 보내 핫이슈 뉴스를 생성하고 저장한다.
    for (String keyword : aiHotissueResponse.getKeywords()) {
        NewsCreateRequest req = new NewsCreateRequest(List.of(keyword));
        save(null, true, req);
    }
}
```

5. **스케줄링 클래스 `NewsSchedulerService`에 핫이슈 뉴스 처리 서비스 메서드 호출**

```java
@Scheduled(cron = "0 0 9 * * *")
@Async
public void createHotissueNews() {
    try {
        log.info("[INFO] 핫이슈 뉴스 생성 시작");
        newsService.createHotissueNews();
        log.info("[INFO] 핫이슈 뉴스 생성 완료");
    } catch (Exception e) {
        log.error("[ERROR] 핫이슈 뉴스 생성 중 오류 발생:", e);
    }
}
```

#### 테스트 추가

- **뉴스 리포지토리 테스트 - `updateIsHotissue()`**
    - 뉴스 핫이슈 전환 시 수정일자 변경되지 않고 유지 검증
        - 핫이슈 → 일반 검증
        - 일반 → 핫이슈 검증
- **뉴스 서비스 테스트 - `createHotissueNews()`**
    - 핫이슈 뉴스 생성 검증
    - 기존 뉴스 핫이슈 전환 검증
        - 기존 뉴스가 업데이트 텀이 지난 경우 검증
        - 기존 뉴스가 업데이트 텀이 지나지 않은 경우 검증
    - 핫이슈 생성 시 기존 핫이슈 뉴스들을 일반 뉴스로 전환 검증

<br/>

## 오래된 뉴스 및 고아 태그 삭제 스케줄링 메서드 추가
1. **`NewsService`에 오래된 뉴스 및 고아 태그 삭제 메서드 생성** 

```java
@Override
public void deleteOldNewsAndOrphanTags() {
    newsRepository.deleteAllOlderThan(LocalDateTime.now().minusDays(NewsServiceConstant.NEWS_DELETE_DAYS));
    tagRepository.deleteAllOrphan();
}
```

#### 테스트 추가

- 오래된 뉴스 및 고아 태그 삭제 검증

2. **`NewsSchedulerService`에 오래된 뉴스 및 고아 태그 삭제 서비스 메서드 호출**

```java
@Override
@Async
@Scheduled(cron = "0 0 9 * * *")
public void deleteOldNewsAndOrphanTags() {
    try {
        log.info("[INFO] 오래된 뉴스 삭제 및 고아 태그 삭제 시작");
        newsService.deleteOldNewsAndOrphanTags();
        log.info("[INFO] 오래된 뉴스 삭제 및 고아 태그 삭제 완료");
    } catch (Exception e) {
        log.error("[ERROR] 오래된 뉴스 삭제 및 고아 태그 삭제 중 오류 발생: {}", e.getMessage(), e);
    }
}
```