### PR TITLE
feat: 알림 기능 API 구현

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/alarm/constant/AlarmResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/constant/AlarmResponseMessage.java
@@ -5,7 +5,7 @@ public final class AlarmResponseMessage {
 
     // 알림 성공 메시지
     public static final String ALARM_FETCH_SUCCESS = "요청하신 알림 목록을 성공적으로 불러왔습니다.";
-    public static final String ALARM_CHECK_SUCCESS = "알림 확인에 성공하였습니다.";
+    public static final String ALARM_CHECK_SUCCESS = "알림을 성공적으로 확인하였습니다.";
 
     // 알림 예외 메시지
     public static final String ALARM_NOT_FOUND = "존재하지 않는 알림입니다.";

--- a/backend/src/main/java/com/tamnara/backend/alarm/constant/AlarmResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/constant/AlarmResponseMessage.java
@@ -1,0 +1,12 @@
+package com.tamnara.backend.alarm.constant;
+
+public final class AlarmResponseMessage {
+    private AlarmResponseMessage() {}
+
+    // 알림 성공 메시지
+    public static final String ALARM_FETCH_SUCCESS = "요청하신 알림 목록을 성공적으로 불러왔습니다.";
+    public static final String ALARM_CHECK_SUCCESS = "알림 확인에 성공하였습니다.";
+
+    // 알림 예외 메시지
+    public static final String ALARM_NOT_FOUND = "존재하지 않는 알림입니다.";
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/constant/AlarmServiceConstant.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/constant/AlarmServiceConstant.java
@@ -1,0 +1,8 @@
+package com.tamnara.backend.alarm.constant;
+
+public final class AlarmServiceConstant {
+    private AlarmServiceConstant() {}
+
+    public static final int ALARM_LIST_SIZE = 20;
+
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/constant/AlarmServiceConstant.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/constant/AlarmServiceConstant.java
@@ -4,5 +4,8 @@ public final class AlarmServiceConstant {
     private AlarmServiceConstant() {}
 
     public static final int ALARM_LIST_SIZE = 20;
+    public static final Long ALARM_DELETE_DAYS = 14L;
+    public static final String ALARM_RESPONSE_TYPE_ALL = "all";
+    public static final String ALARM_RESPONSE_TYPE_BOOKMARK = "bookmark";
 
 }

--- a/backend/src/main/java/com/tamnara/backend/alarm/controller/AlarmController.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/controller/AlarmController.java
@@ -1,0 +1,92 @@
+package com.tamnara.backend.alarm.controller;
+
+import com.tamnara.backend.alarm.constant.AlarmResponseMessage;
+import com.tamnara.backend.alarm.dto.response.AlarmListResponse;
+import com.tamnara.backend.alarm.service.AlarmService;
+import com.tamnara.backend.global.constant.ResponseMessage;
+import com.tamnara.backend.global.dto.WrappedDTO;
+import com.tamnara.backend.global.exception.CustomException;
+import com.tamnara.backend.user.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users/me/alarms")
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @GetMapping
+    public ResponseEntity<WrappedDTO<List<AlarmListResponse>>> getAlarmPage(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        try {
+            if (userDetails == null || userDetails.getUser() == null) {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ResponseMessage.USER_NOT_CERTIFICATION);
+            }
+
+            Long userId = userDetails.getUser().getId();
+
+            List<AlarmListResponse> alarmList = new ArrayList<>();
+            alarmList.add(alarmService.getAllAlarmPageByUserId(userId));
+            alarmList.add(alarmService.getBookmarkAlarmPageByUserId(userId));
+
+            return ResponseEntity.ok().body(
+                    new WrappedDTO<>(
+                            true,
+                            AlarmResponseMessage.ALARM_FETCH_SUCCESS,
+                            alarmList
+                    ));
+
+        } catch (ResponseStatusException e) {
+            throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_REQUEST);
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PatchMapping("/{alarmId}")
+    public ResponseEntity<WrappedDTO<Long>> checkAlarm(
+            @PathVariable Long alarmId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        try {
+            if (userDetails == null || userDetails.getUser() == null) {
+                throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, ResponseMessage.USER_NOT_CERTIFICATION);
+            }
+
+            Long userId = userDetails.getUser().getId();
+            Long checkedAlarmId = alarmService.checkUserAlarm(alarmId, userId);
+
+            return ResponseEntity.ok().body(
+                    new WrappedDTO<>(
+                            true,
+                            AlarmResponseMessage.ALARM_CHECK_SUCCESS,
+                            checkedAlarmId
+                    ));
+
+        } catch (ResponseStatusException e) {
+            throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_REQUEST);
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/domain/Alarm.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/domain/Alarm.java
@@ -1,0 +1,47 @@
+package com.tamnara.backend.alarm.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(of = "id")
+@Table(name = "alarms")
+public class Alarm {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", length = 14, nullable = false)
+    private String title;
+
+    @Column(name = "content", length = 255, nullable = false)
+    private String content;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", length = 50, nullable = true)
+    private AlarmType targetType;
+
+    @Column(name = "target_id", nullable = true)
+    private Long targetId;
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/domain/AlarmType.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/domain/AlarmType.java
@@ -1,0 +1,6 @@
+package com.tamnara.backend.alarm.domain;
+
+public enum AlarmType {
+    NEWS,
+    POLL
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/domain/UserAlarm.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/domain/UserAlarm.java
@@ -1,0 +1,50 @@
+package com.tamnara.backend.alarm.domain;
+
+import com.tamnara.backend.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@EqualsAndHashCode(of = "id")
+@Table(name = "user_alarm", indexes = @Index(name = "idx_user_id_id_desc", columnList = "user_id, id DESC"))
+public class UserAlarm {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "is_checked", nullable = false)
+    private Boolean isChecked = false;
+
+    @Column(name = "checked_at", nullable = true)
+    private LocalDateTime checkedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "alarm_id", referencedColumnName = "id", nullable = false, updatable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Alarm alarm;
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/dto/AlarmCardDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/dto/AlarmCardDTO.java
@@ -1,0 +1,28 @@
+package com.tamnara.backend.alarm.dto;
+
+import com.tamnara.backend.alarm.domain.AlarmType;
+import com.tamnara.backend.news.util.ValueOfEnum;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class AlarmCardDTO {
+    private Long id;
+
+    @Length(max = 14, message = "알림 제목은 14자까지만 가능합니다.")
+    private String title;
+
+    @Length(max = 255, message = "알림 내용은 255자까지만 가능합니다.")
+    private String content;
+
+    private Boolean isChecked;
+    private LocalDateTime checkedAt;
+
+    @ValueOfEnum(enumClass = AlarmType.class, message = "타겟 종류 값이 올바르지 않습니다.")
+    private String targetType;
+    private Long targetId;
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/dto/response/AlarmListResponse.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/dto/response/AlarmListResponse.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.alarm.dto.response;
+
+import com.tamnara.backend.alarm.dto.AlarmCardDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AlarmListResponse {
+    private String type;
+    private List<AlarmCardDTO> alarms;
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/repository/AlarmRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/repository/AlarmRepository.java
@@ -1,0 +1,26 @@
+package com.tamnara.backend.alarm.repository;
+
+import com.tamnara.backend.alarm.domain.Alarm;
+import com.tamnara.backend.alarm.domain.AlarmType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+    List<Alarm> findByTargetTypeAndTargetIdOrderByIdDesc(AlarmType targetType, Long targetId);
+
+    @Modifying
+    @Transactional
+    @Query("""
+        DELETE FROM Alarm a
+        WHERE a.createdAt < :cutoff
+    """)
+    void deleteAllOlderThan(@Param("cutoff") LocalDateTime cutoff);
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/repository/UserAlarmRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/repository/UserAlarmRepository.java
@@ -1,0 +1,26 @@
+package com.tamnara.backend.alarm.repository;
+
+import com.tamnara.backend.alarm.domain.UserAlarm;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface UserAlarmRepository extends JpaRepository<UserAlarm, Long> {
+    Page<UserAlarm> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+    Boolean existsByIdAndIsCheckedTrue(Long userAlarmId);
+
+    @Modifying
+    @Query("""
+        UPDATE UserAlarm ua
+        SET ua.isChecked = true, ua.checkedAt = :checkedAt
+        WHERE ua.id = :userAlarmId
+    """)
+    void checkUserAlarm(@Param("userAlarmId") Long userAlarmId, @Param("checkedAt") LocalDateTime checkedAt);
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/repository/UserAlarmRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/repository/UserAlarmRepository.java
@@ -14,7 +14,20 @@ import java.time.LocalDateTime;
 @Repository
 public interface UserAlarmRepository extends JpaRepository<UserAlarm, Long> {
     Page<UserAlarm> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
-    Boolean existsByIdAndIsCheckedTrue(Long userAlarmId);
+
+    @Query("""
+        SELECT ua FROM UserAlarm ua
+        JOIN ua.alarm a
+        JOIN Bookmark b ON b.news.id = a.targetId
+        WHERE ua.user.id = :userId
+          AND b.user.id = :userId
+          AND a.targetType = com.tamnara.backend.alarm.domain.AlarmType.NEWS
+        ORDER BY ua.id DESC
+    """)
+    Page<UserAlarm> findBookmarkAlarms(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
 
     @Modifying
     @Query("""

--- a/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmSchedulerService.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmSchedulerService.java
@@ -1,0 +1,5 @@
+package com.tamnara.backend.alarm.service;
+
+public interface AlarmSchedulerService {
+    void deleteOldAlarms();
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmSchedulerServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmSchedulerServiceImpl.java
@@ -17,7 +17,7 @@ public class AlarmSchedulerServiceImpl implements AlarmSchedulerService {
 
     @Override
     @Async
-    @Scheduled(cron = "0 3 16 * * *")
+    @Scheduled(cron = "0 0 9 * * *")
     public void deleteOldAlarms() {
         try {
             log.info("[INFO] 오래된 알림 일괄 삭제 시작");

--- a/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmSchedulerServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmSchedulerServiceImpl.java
@@ -1,0 +1,34 @@
+package com.tamnara.backend.alarm.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class AlarmSchedulerServiceImpl implements AlarmSchedulerService {
+
+    private final AlarmService alarmService;
+
+    public AlarmSchedulerServiceImpl(AlarmService alarmService) {
+        this.alarmService = alarmService;
+    }
+
+    @Override
+    @Async
+    @Scheduled(cron = "0 3 16 * * *")
+    public void deleteOldAlarms() {
+        try {
+            log.info("[INFO] 오래된 알림 일괄 삭제 시작");
+            Long start = System.currentTimeMillis();
+
+            alarmService.deleteAlarms();
+
+            Long end = System.currentTimeMillis();
+            log.info("[INFO] 오래된 알림 일괄 삭제 완료: {} ms", (end - start));
+        } catch (Exception e) {
+            log.error("[ERROR] 오래된 알림 일괄 삭제 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmService.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmService.java
@@ -1,0 +1,11 @@
+package com.tamnara.backend.alarm.service;
+
+import com.tamnara.backend.alarm.dto.response.AlarmListResponse;
+
+public interface AlarmService {
+    AlarmListResponse getAllAlarmPageByUserId(Long userId);
+    AlarmListResponse getBookmarkAlarmPageByUserId(Long userId);
+    Long checkUserAlarm(Long userAlarmId, Long userId);
+
+    void deleteAlarms();
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmServiceImpl.java
@@ -1,0 +1,105 @@
+package com.tamnara.backend.alarm.service;
+
+import com.tamnara.backend.alarm.constant.AlarmResponseMessage;
+import com.tamnara.backend.alarm.constant.AlarmServiceConstant;
+import com.tamnara.backend.alarm.domain.Alarm;
+import com.tamnara.backend.alarm.domain.UserAlarm;
+import com.tamnara.backend.alarm.dto.AlarmCardDTO;
+import com.tamnara.backend.alarm.dto.response.AlarmListResponse;
+import com.tamnara.backend.alarm.repository.AlarmRepository;
+import com.tamnara.backend.alarm.repository.UserAlarmRepository;
+import com.tamnara.backend.global.constant.ResponseMessage;
+import com.tamnara.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmServiceImpl implements AlarmService {
+
+    private final UserAlarmRepository userAlarmRepository;
+    private final UserRepository userRepository;
+    private final AlarmRepository alarmRepository;
+
+    @Override
+    public AlarmListResponse getAllAlarmPageByUserId(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(0, AlarmServiceConstant.ALARM_LIST_SIZE);
+        Page<UserAlarm> userAlarmPage = userAlarmRepository.findByUserIdOrderByIdDesc(userId, pageable);
+
+        return new AlarmListResponse(
+                AlarmServiceConstant.ALARM_RESPONSE_TYPE_ALL,
+                getAlarmCardDTOList(userAlarmPage)
+        );
+    }
+
+    @Override
+    public AlarmListResponse getBookmarkAlarmPageByUserId(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(0, AlarmServiceConstant.ALARM_LIST_SIZE);
+        Page<UserAlarm> userAlarmPage = userAlarmRepository.findBookmarkAlarms(userId, pageable);
+
+        return new AlarmListResponse(
+                AlarmServiceConstant.ALARM_RESPONSE_TYPE_BOOKMARK,
+                getAlarmCardDTOList(userAlarmPage)
+        );
+    }
+
+    @Override
+    public Long checkUserAlarm(Long userAlarmId, Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
+
+        UserAlarm userAlarm = userAlarmRepository.findById(userAlarmId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, AlarmResponseMessage.ALARM_NOT_FOUND));
+
+        if (!userAlarm.getIsChecked()) {
+            userAlarmRepository.checkUserAlarm(userAlarmId, LocalDateTime.now());
+        }
+
+        return userAlarm.getId();
+    }
+
+    @Override
+    public void deleteAlarms() {
+        alarmRepository.deleteAllOlderThan(LocalDateTime.now().minusDays(AlarmServiceConstant.ALARM_DELETE_DAYS));
+    }
+
+
+    /**
+     * 헬퍼 메서드
+     */
+    private List<AlarmCardDTO> getAlarmCardDTOList(Page<UserAlarm> userAlarmPage) {
+        List<AlarmCardDTO> alarmCardDTOList = new ArrayList<>();
+
+        for (UserAlarm userAlarm : userAlarmPage) {
+            Alarm alarm = userAlarm.getAlarm();
+
+            AlarmCardDTO dto = new AlarmCardDTO(
+                    alarm.getId(),
+                    alarm.getTitle(),
+                    alarm.getContent(),
+                    userAlarm.getIsChecked(),
+                    userAlarm.getCheckedAt(),
+                    alarm.getTargetType() == null ? null : alarm.getTargetType().toString(),
+                    alarm.getTargetId()
+            );
+            alarmCardDTOList.add(dto);
+        }
+
+        return alarmCardDTOList;
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmServiceImpl.java
@@ -10,6 +10,7 @@ import com.tamnara.backend.alarm.repository.AlarmRepository;
 import com.tamnara.backend.alarm.repository.UserAlarmRepository;
 import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -59,6 +60,7 @@ public class AlarmServiceImpl implements AlarmService {
     }
 
     @Override
+    @Transactional
     public Long checkUserAlarm(Long userAlarmId, Long userId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));

--- a/backend/src/main/java/com/tamnara/backend/global/security/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/tamnara/backend/global/security/CustomAuthenticationEntryPoint.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private final ObjectMapper objectMapper = new ObjectMapper(); // 수동 생성 or 주입
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public void commence(

--- a/backend/src/test/java/com/tamnara/backend/alarm/config/AlarmServiceMockConfig.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/config/AlarmServiceMockConfig.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.alarm.config;
+
+import com.tamnara.backend.alarm.service.AlarmService;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class AlarmServiceMockConfig {
+    @Bean
+    public AlarmService alarmService() {
+        return Mockito.mock(AlarmService.class);
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/alarm/controller/AlarmControllerTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/controller/AlarmControllerTest.java
@@ -1,0 +1,146 @@
+package com.tamnara.backend.alarm.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tamnara.backend.alarm.config.AlarmServiceMockConfig;
+import com.tamnara.backend.alarm.constant.AlarmResponseMessage;
+import com.tamnara.backend.alarm.constant.AlarmServiceConstant;
+import com.tamnara.backend.alarm.domain.AlarmType;
+import com.tamnara.backend.alarm.dto.AlarmCardDTO;
+import com.tamnara.backend.alarm.dto.response.AlarmListResponse;
+import com.tamnara.backend.alarm.service.AlarmService;
+import com.tamnara.backend.global.constant.ResponseMessage;
+import com.tamnara.backend.user.domain.Role;
+import com.tamnara.backend.user.domain.User;
+import com.tamnara.backend.user.security.UserDetailsImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AlarmController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(AlarmServiceMockConfig.class)
+@ActiveProfiles("test")
+public class AlarmControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Autowired private AlarmService alarmService;
+
+    private static final Long USER_ID = 1L;
+
+    private AlarmCardDTO createAlarmCardDTO(Long id, Boolean isChecked, String targetType, Long targetId) {
+        return new AlarmCardDTO(
+                id,
+                "제목",
+                "내용",
+                isChecked,
+                isChecked ? LocalDateTime.now() : null,
+                targetType,
+                targetId
+        );
+    }
+
+    @BeforeEach
+    void setupSecurityContext() {
+        User user = User.builder()
+                .id(USER_ID)
+                .username("테스트유저")
+                .role(Role.USER)
+                .build();
+
+        UserDetailsImpl principal = new UserDetailsImpl(user);
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities())
+        );
+    }
+
+    @Test
+    void 로그아웃_상태에서_알림_카드_목록_조회_불가_검증() throws Exception {
+        // given
+        SecurityContextHolder.clearContext();
+
+        // when & then
+        mockMvc.perform(get("/users/me/alarms"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ResponseMessage.USER_NOT_CERTIFICATION));
+    }
+
+    @Test
+    void 로그인_상태에서_알림_카드_목록_조회_검증() throws Exception {
+        // given
+        AlarmCardDTO alarmCardDTO1 = createAlarmCardDTO(1L, false, AlarmType.NEWS.toString(), 1L);
+        AlarmCardDTO alarmCardDTO2 = createAlarmCardDTO(2L, false, AlarmType.NEWS.toString(), 1L);
+        AlarmCardDTO alarmCardDTO3 = createAlarmCardDTO(3L, false, AlarmType.POLL.toString(), 1L);
+        AlarmCardDTO alarmCardDTO4 = createAlarmCardDTO(4L, false, AlarmType.POLL.toString(), 1L);
+        AlarmCardDTO alarmCardDTO5 = createAlarmCardDTO(5L, false, null, null);
+        List<AlarmCardDTO> allAlarmCardDTOList = List.of(alarmCardDTO1, alarmCardDTO2, alarmCardDTO3, alarmCardDTO4, alarmCardDTO5);
+        List<AlarmCardDTO> bookmarkAlarmCardDTOList = List.of(alarmCardDTO1, alarmCardDTO2);
+
+        AlarmListResponse allAlarms = new AlarmListResponse (
+                AlarmServiceConstant.ALARM_RESPONSE_TYPE_ALL,
+                allAlarmCardDTOList
+        );
+
+        AlarmListResponse bookmarkAlarms = new AlarmListResponse (
+                AlarmServiceConstant.ALARM_RESPONSE_TYPE_BOOKMARK,
+                bookmarkAlarmCardDTOList
+        );
+
+        given(alarmService.getAllAlarmPageByUserId(USER_ID)).willReturn(allAlarms);
+        given(alarmService.getBookmarkAlarmPageByUserId(USER_ID)).willReturn(bookmarkAlarms);
+
+        // when & then
+        mockMvc.perform(get("/users/me/alarms"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value(AlarmResponseMessage.ALARM_FETCH_SUCCESS))
+                .andExpect(jsonPath("$.data[0].type").value(AlarmServiceConstant.ALARM_RESPONSE_TYPE_ALL))
+                .andExpect(jsonPath("$.data[1].type").value(AlarmServiceConstant.ALARM_RESPONSE_TYPE_BOOKMARK));
+
+    }
+
+    @Test
+    void 로그아웃_상태에서_단일_알림_확인_불가_검증() throws Exception {
+        // given
+        SecurityContextHolder.clearContext();
+
+        // when & then
+        mockMvc.perform(patch("/users/me/alarms/{alarmId}", 1))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ResponseMessage.USER_NOT_CERTIFICATION));
+    }
+
+    @Test
+    void 로그인_상태에서_단일_알림_확인_검증() throws Exception {
+        // given
+        Long alarmId = 1L;
+        given(alarmService.checkUserAlarm(alarmId, USER_ID)).willReturn(alarmId);
+
+        // when & then
+        mockMvc.perform(patch("/users/me/alarms/{alarmId}", alarmId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value(AlarmResponseMessage.ALARM_CHECK_SUCCESS))
+                .andExpect(jsonPath("$.data").value(alarmId));
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/alarm/domain/AlarmTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/domain/AlarmTest.java
@@ -1,0 +1,95 @@
+package com.tamnara.backend.alarm.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AlarmTest {
+
+    @Test
+    void 알림_기본값_초기화_검증() {
+        // given & when
+        Alarm alarm = new Alarm();
+
+        // then
+        assertNull(alarm.getId());
+        assertNull(alarm.getTitle());
+        assertNull(alarm.getContent());
+        assertNull(alarm.getCreatedAt());
+        assertNull(alarm.getTargetType());
+        assertNull(alarm.getTargetId());
+    }
+
+    @Test
+    void 알림_제목과_내용과_타겟종류와_타겟ID_설정_검증() {
+        // given
+        Alarm alarm = new Alarm();
+
+        // when
+        alarm.setTitle("제목");
+        alarm.setContent("내용");
+        alarm.setTargetType(AlarmType.NEWS);
+        alarm.setTargetId(1L);
+
+        // then
+        assertEquals("제목", alarm.getTitle());
+        assertEquals("내용", alarm.getContent());
+        assertEquals(AlarmType.NEWS, alarm.getTargetType());
+        assertEquals(1L, alarm.getTargetId());
+    }
+
+    @Test
+    void ID가_동일하면_동일한_알림_검증() {
+        // given
+        Alarm alarm1 = new Alarm();
+        Alarm alarm2 = new Alarm();
+
+        // when
+        alarm1.setId(1L);
+        alarm2.setId(1L);
+
+        // then
+        assertEquals(alarm1, alarm2);
+    }
+
+    @Test
+    void 알림_종류의_전체_정의값_검증() {
+        // given & when
+        AlarmType[] values = AlarmType.values();
+
+        // then
+        assertThat(values).containsExactlyInAnyOrder(
+                AlarmType.NEWS,
+                AlarmType.POLL
+        );
+    }
+
+    @Test
+    void 문자열로부터_enum_변환_검증() {
+        // given
+        String input1 = "NEWS";
+        String input2 = "POLL";
+
+        // when
+        AlarmType result1 = AlarmType.valueOf(input1);
+        AlarmType result2 = AlarmType.valueOf(input2);
+
+        // then
+        assertEquals(AlarmType.NEWS, result1);
+        assertEquals(AlarmType.POLL, result2);
+    }
+
+    @Test
+    void 잘못된_문자열이_enum_변환에_실패_검증() {
+        // given
+        String invalidInput = "INVALID";
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> {
+            AlarmType.valueOf(invalidInput);
+        });
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/alarm/domain/UserAlarmTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/domain/UserAlarmTest.java
@@ -1,0 +1,79 @@
+package com.tamnara.backend.alarm.domain;
+
+import com.tamnara.backend.user.domain.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class UserAlarmTest {
+
+    @Test
+    void 회원알림_기본값_초기화_검증() {
+        // given & when
+        UserAlarm userAlarm = new UserAlarm();
+
+        // then
+        assertNull(userAlarm.getId());
+        assertFalse(userAlarm.getIsChecked());
+        assertNull(userAlarm.getCheckedAt());
+        assertNull(userAlarm.getUser());
+        assertNull(userAlarm.getAlarm());
+    }
+
+    @Test
+    void 회원알림_회원과_알림_설정_검증() {
+        // given
+        UserAlarm userAlarm = new UserAlarm();
+        User user = User.builder().build();
+        Alarm alarm = new Alarm();
+
+        // when
+        LocalDateTime now = LocalDateTime.now();
+        userAlarm.setUser(user);
+        userAlarm.setAlarm(alarm);
+
+        // then
+        assertEquals(user, userAlarm.getUser());
+        assertEquals(alarm, userAlarm.getAlarm());
+    }
+
+    @Test
+    void 회원알림_확인_여부와_확인_시간_설정_검증() {
+        // given
+        UserAlarm userAlarm = new UserAlarm();
+        User user = User.builder().build();
+        Alarm alarm = new Alarm();
+
+        userAlarm.setUser(user);
+        userAlarm.setAlarm(alarm);
+
+        // when
+        LocalDateTime now = LocalDateTime.now();
+        userAlarm.setIsChecked(true);
+        userAlarm.setCheckedAt(now);
+
+        // then
+        assertTrue(userAlarm.getIsChecked());
+        assertEquals(now, userAlarm.getCheckedAt());
+    }
+
+
+    @Test
+    void ID가_동일하면_동일한_회원알림_검증() {
+        // given
+        UserAlarm userAlarm1 = new UserAlarm();
+        UserAlarm userAlarm2 = new UserAlarm();
+
+        // when
+        userAlarm1.setId(1L);
+        userAlarm2.setId(1L);
+
+        // then
+        assertEquals(userAlarm1, userAlarm2);
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/alarm/repository/AlarmRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/repository/AlarmRepositoryTest.java
@@ -1,0 +1,346 @@
+package com.tamnara.backend.alarm.repository;
+
+import com.tamnara.backend.alarm.domain.Alarm;
+import com.tamnara.backend.alarm.domain.AlarmType;
+import com.tamnara.backend.alarm.domain.UserAlarm;
+import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.user.domain.Role;
+import com.tamnara.backend.user.domain.State;
+import com.tamnara.backend.user.domain.User;
+import com.tamnara.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@Import({JpaConfig.class, QuerydslConfig.class})
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class AlarmRepositoryTest {
+
+    @PersistenceContext private EntityManager em;
+
+    @Autowired private AlarmRepository alarmRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserAlarmRepository userAlarmRepository;
+
+    private Alarm createAlarm(String title, String content, String targetType, Long targetId) {
+        Alarm alarm = new Alarm();
+        alarm.setTitle(title);
+        alarm.setContent(content);
+        alarm.setTargetType(targetType == null ? null : AlarmType.valueOf(targetType));
+        alarm.setTargetId(targetId);
+
+        return alarm;
+    }
+
+    private UserAlarm createUserAlarm(boolean isChecked, LocalDateTime checkedAt, User user, Alarm alarm) {
+        UserAlarm userAlarm = new UserAlarm();
+        userAlarm.setIsChecked(isChecked);
+        userAlarm.setCheckedAt(checkedAt);
+        userAlarm.setUser(user);
+        userAlarm.setAlarm(alarm);
+        return userAlarm;
+    }
+
+    @BeforeEach
+    void setUp() {
+        alarmRepository.deleteAll();
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    void 알림_생성_성공_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+        alarmRepository.saveAndFlush(alarm);
+        em.clear();
+
+        // when
+        Optional<Alarm> findAlarm = alarmRepository.findById(alarm.getId());
+
+        // then
+        assertEquals(alarm.getId(), findAlarm.get().getId());
+    }
+
+    @Test
+    void 알림_제목_null_불가_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+
+        // when
+        alarm.setTitle(null);
+
+        // then
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            alarmRepository.saveAndFlush(alarm);
+        });
+    }
+
+    @Test
+    void 알림_제목_길이_제약_검증() {
+        // given
+        String shortTitle = "가".repeat(14);
+        String longTitle = "가".repeat(15);
+
+        // when
+        Alarm validAlarm = createAlarm(shortTitle, "내용", AlarmType.NEWS.toString(), 1L);
+        Alarm invalidAlarm = createAlarm(longTitle, "내용", AlarmType.NEWS.toString(), 1L);
+
+        // then
+        Alarm savedValidAlarm = alarmRepository.saveAndFlush(validAlarm);
+        assertNotNull(savedValidAlarm.getId());
+        assertEquals(validAlarm.getTitle(), savedValidAlarm.getTitle());
+
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            alarmRepository.saveAndFlush(invalidAlarm);
+        });
+    }
+
+    @Test
+    void 알림_내용_null_불가_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+
+        // when
+        alarm.setTitle(null);
+
+        // then
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            alarmRepository.saveAndFlush(alarm);
+        });
+    }
+
+    @Test
+    void 알림_내용_길이_제약_검증() {
+        // given
+        String shortContent = "가".repeat(255);
+        String longContent = "가".repeat(256);
+
+        // when
+        Alarm validAlarm = createAlarm("제목", shortContent, AlarmType.NEWS.toString(), 1L);
+        Alarm invalidAlarm = createAlarm("제목", longContent, AlarmType.NEWS.toString(), 1L);
+
+        // then
+        Alarm savedValidAlarm = alarmRepository.saveAndFlush(validAlarm);
+        assertNotNull(savedValidAlarm.getId());
+        assertEquals(validAlarm.getContent(), savedValidAlarm.getContent());
+
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            alarmRepository.saveAndFlush(invalidAlarm);
+        });
+    }
+
+    @Test
+    void 알림_타겟_종류_null_가능_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+
+        // when
+        alarm.setTargetType(null);
+        Alarm savedAlarm = alarmRepository.saveAndFlush(alarm);
+
+        // then
+        assertNotNull(savedAlarm.getId());
+        assertNull(savedAlarm.getTargetType());
+    }
+
+    @Test
+    void 알림_타겟_ID_null_가능_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+
+        // when
+        alarm.setTargetId(null);
+        Alarm savedAlarm = alarmRepository.saveAndFlush(alarm);
+
+        // then
+        assertNotNull(savedAlarm.getId());
+        assertNull(savedAlarm.getTargetId());
+    }
+
+    @Test
+    void 알림_생성일자_자동_생성_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+        alarmRepository.saveAndFlush(alarm);
+        em.clear();
+
+        // when
+        Optional<Alarm> findAlarm = alarmRepository.findById(alarm.getId());
+
+        // then
+        assertNotNull(findAlarm.get().getCreatedAt());
+    }
+
+    @Test
+    void 알림_수정_성공_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+        alarmRepository.saveAndFlush(alarm);
+        em.clear();
+
+        // when
+        Alarm findAlarm = alarmRepository.findById(alarm.getId()).get();
+        findAlarm.setTitle("새로운 제목");
+        findAlarm.setContent("새로운 내용");
+        findAlarm.setTargetType(AlarmType.POLL);
+        findAlarm.setTargetId(2L);
+        alarmRepository.saveAndFlush(findAlarm);
+        em.clear();
+
+        // then
+        Alarm updatedAlarm = alarmRepository.findById(alarm.getId()).get();
+        assertEquals(updatedAlarm.getTitle(), findAlarm.getTitle());
+        assertEquals(updatedAlarm.getContent(), findAlarm.getContent());
+        assertEquals(updatedAlarm.getTargetType(), findAlarm.getTargetType());
+        assertEquals(updatedAlarm.getTargetId(), findAlarm.getTargetId());
+    }
+
+    @Test
+    void 알림_삭제_성공_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+        alarmRepository.saveAndFlush(alarm);
+        em.clear();
+
+        // when
+        Alarm findAlarm = alarmRepository.findById(alarm.getId()).get();
+        alarmRepository.delete(findAlarm);
+        em.flush();
+        em.clear();
+
+        // then
+        assertFalse(alarmRepository.findById(alarm.getId()).isPresent());
+    }
+
+    @Test
+    void 알림_삭제_시_연관된_회원알림_CASCADE_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+        alarmRepository.saveAndFlush(alarm);
+
+        User user = User.builder()
+                .email("이메일")
+                .password("비밀번호")
+                .username("이름")
+                .provider("LOCAL")
+                .providerId(null)
+                .role(Role.USER)
+                .state(State.ACTIVE)
+                .build();
+        userRepository.saveAndFlush(user);
+        em.clear();
+
+        UserAlarm userAlarm1 = createUserAlarm(false, null, user, alarm);
+        userAlarmRepository.saveAndFlush(userAlarm1);
+        UserAlarm userAlarm2 = createUserAlarm(true, LocalDateTime.now(), user, alarm);
+        userAlarmRepository.saveAndFlush(userAlarm2);
+        UserAlarm userAlarm3 = createUserAlarm(false, null, user, alarm);
+        userAlarmRepository.saveAndFlush(userAlarm3);
+        em.clear();
+
+        // when
+        alarmRepository.deleteAll();
+        em.flush();
+        em.clear();
+
+        // then
+        assertFalse(userAlarmRepository.findById(userAlarm1.getId()).isPresent());
+        assertFalse(userAlarmRepository.findById(userAlarm2.getId()).isPresent());
+        assertFalse(userAlarmRepository.findById(userAlarm3.getId()).isPresent());
+    }
+
+    @Test
+    void 단일_알림_조회_성공_검증() {
+        // given
+        Alarm alarm = createAlarm("제목", "내용", AlarmType.NEWS.toString(), 1L);
+        alarmRepository.saveAndFlush(alarm);
+        em.clear();
+
+        // when
+        Optional<Alarm> findAlarm = alarmRepository.findById(alarm.getId());
+
+        // then
+        assertEquals(findAlarm.get().getId(), alarm.getId());
+    }
+
+    @Test
+    void 타겟_종류와_타겟_ID로_알림_목록_조회_시_ID_내림차순_정렬_검증() {
+        // given
+        AlarmType targetType = AlarmType.NEWS;
+        Long targetId = 1L;
+
+        Alarm alarm1 = createAlarm("제목1", "내용1", targetType.toString(), targetId);
+        Alarm alarm2 = createAlarm("제목2", "내용2", targetType.toString(), targetId);
+        Alarm alarm3 = createAlarm("제목3", "내용3", targetType.toString(), targetId);
+        alarmRepository.saveAndFlush(alarm1);
+        alarmRepository.saveAndFlush(alarm2);
+        alarmRepository.saveAndFlush(alarm3);
+        em.clear();
+
+        // when
+        List<Alarm> findAlarmList = alarmRepository.findByTargetTypeAndTargetIdOrderByIdDesc(targetType, targetId);
+
+        // then
+        assertEquals(findAlarmList.get(0).getId(), alarm3.getId());
+        assertEquals(findAlarmList.get(1).getId(), alarm2.getId());
+        assertEquals(findAlarmList.get(2).getId(), alarm1.getId());
+    }
+
+    @Test
+    void 생성일자가_기준보다_오래된_알림_일괄_삭제_검증() {
+        // given
+        Alarm alarm1 = createAlarm("제목1", "내용1", AlarmType.NEWS.toString(), 1L);
+        alarmRepository.saveAndFlush(alarm1);
+        em.clear();
+
+        Alarm alarm2 = createAlarm("제목2", "내용2", null, null);
+        alarmRepository.saveAndFlush(alarm2);
+        em.clear();
+
+        LocalDateTime cutoff;
+        try {
+            Thread.sleep(1000); // 1초
+            cutoff = LocalDateTime.now();
+            Thread.sleep(1000); // 1초
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        Alarm alarm3 = createAlarm("제목3", "내용3", AlarmType.POLL.toString(), 2L);
+        alarmRepository.saveAndFlush(alarm3);
+        em.clear();
+
+        // when
+        alarmRepository.deleteAllOlderThan(cutoff);
+        em.flush();
+        em.clear();
+
+        // then
+        assertFalse(alarmRepository.findById(alarm1.getId()).isPresent());
+        assertFalse(alarmRepository.findById(alarm2.getId()).isPresent());
+        assertTrue(alarmRepository.findById(alarm3.getId()).isPresent());
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/alarm/repository/UserAlarmRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/repository/UserAlarmRepositoryTest.java
@@ -3,8 +3,12 @@ package com.tamnara.backend.alarm.repository;
 import com.tamnara.backend.alarm.domain.Alarm;
 import com.tamnara.backend.alarm.domain.AlarmType;
 import com.tamnara.backend.alarm.domain.UserAlarm;
+import com.tamnara.backend.bookmark.domain.Bookmark;
+import com.tamnara.backend.bookmark.repository.BookmarkRepository;
 import com.tamnara.backend.global.config.JpaConfig;
 import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.news.domain.News;
+import com.tamnara.backend.news.repository.NewsRepository;
 import com.tamnara.backend.user.domain.Role;
 import com.tamnara.backend.user.domain.State;
 import com.tamnara.backend.user.domain.User;
@@ -44,11 +48,14 @@ public class UserAlarmRepositoryTest {
     @PersistenceContext private EntityManager em;
 
     @Autowired private UserAlarmRepository userAlarmRepository;
-    @Autowired private UserRepository userRepository;
     @Autowired private AlarmRepository alarmRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private NewsRepository newsRepository;
+    @Autowired private BookmarkRepository bookmarkRepository;
 
     User user;
     Alarm alarm;
+    News news;
 
     @BeforeEach
     void setUp() {
@@ -77,7 +84,7 @@ public class UserAlarmRepositoryTest {
         em.clear();
     }
 
-    private UserAlarm createUserAlarm(boolean isChecked) {
+    private UserAlarm createUserAlarm(Alarm alarm, boolean isChecked) {
         UserAlarm userAlarm = new UserAlarm();
         userAlarm.setIsChecked(isChecked);
         userAlarm.setCheckedAt(isChecked ? LocalDateTime.now() : null);
@@ -86,10 +93,35 @@ public class UserAlarmRepositoryTest {
         return userAlarm;
     }
 
+    private Alarm createAlarm(String title, String content, String targetType, Long targetId) {
+        Alarm alarm = new Alarm();
+        alarm.setTitle(title);
+        alarm.setContent(content);
+        alarm.setTargetType(targetType == null ? null : AlarmType.valueOf(targetType));
+        alarm.setTargetId(targetId);
+
+        return alarmRepository.saveAndFlush(alarm);
+    }
+
+    private News createNews() {
+        news = new News();
+        news.setTitle("제목");
+        news.setSummary("미리보기 내용");
+        news.setIsHotissue(true);
+        return newsRepository.saveAndFlush(news);
+    }
+
+    private Bookmark createBookmark(News news) {
+        Bookmark bookmark = new Bookmark();
+        bookmark.setUser(user);
+        bookmark.setNews(news);
+        return bookmarkRepository.saveAndFlush(bookmark);
+    }
+
     @Test
     void 회원알림_생성_성공_검증() {
         // given
-        UserAlarm userAlarm = createUserAlarm(false);
+        UserAlarm userAlarm = createUserAlarm(alarm, false);
         userAlarmRepository.save(userAlarm);
 
         // when
@@ -102,7 +134,7 @@ public class UserAlarmRepositoryTest {
     @Test
     void 회원알림_확인_여부_null_불가_검증() {
         // given
-        UserAlarm userAlarm = createUserAlarm(true);
+        UserAlarm userAlarm = createUserAlarm(alarm, true);
 
         // when
         userAlarm.setIsChecked(null);
@@ -116,7 +148,7 @@ public class UserAlarmRepositoryTest {
     @Test
     void 회원알림_확인_시간_null_가능_검증() {
         // given
-        UserAlarm userAlarm = createUserAlarm(true);
+        UserAlarm userAlarm = createUserAlarm(alarm, true);
 
         // when
         userAlarm.setCheckedAt(null);
@@ -131,7 +163,7 @@ public class UserAlarmRepositoryTest {
     @Test
     void 회원알림_회원_필드_null_불가_검증() {
         // given
-        UserAlarm userAlarm = createUserAlarm(true);
+        UserAlarm userAlarm = createUserAlarm(alarm, true);
 
         // when
         userAlarm.setUser(null);
@@ -145,7 +177,7 @@ public class UserAlarmRepositoryTest {
     @Test
     void 회원알림_알림_필드_null_불가_검증() {
         // given
-        UserAlarm userAlarm = createUserAlarm(true);
+        UserAlarm userAlarm = createUserAlarm(alarm, true);
 
         // when
         userAlarm.setAlarm(null);
@@ -159,7 +191,7 @@ public class UserAlarmRepositoryTest {
     @Test
     void 회원알림_확인_상태_업데이트_성공_검증() {
         // given
-        UserAlarm userAlarm = createUserAlarm(false);
+        UserAlarm userAlarm = createUserAlarm(alarm, false);
         userAlarmRepository.saveAndFlush(userAlarm);
         em.clear();
 
@@ -180,7 +212,7 @@ public class UserAlarmRepositoryTest {
     @Test
     void 회원알림_삭제_성공_검증() {
         // given
-        UserAlarm userAlarm = createUserAlarm(false);
+        UserAlarm userAlarm = createUserAlarm(alarm, false);
         userAlarmRepository.saveAndFlush(userAlarm);
         em.clear();
 
@@ -194,7 +226,7 @@ public class UserAlarmRepositoryTest {
     @Test
     void 단일_회원알림_조회_성공_검증() {
         // given
-        UserAlarm userAlarm = createUserAlarm(false);
+        UserAlarm userAlarm = createUserAlarm(alarm, false);
         userAlarmRepository.saveAndFlush(userAlarm);
         em.clear();
 
@@ -208,15 +240,15 @@ public class UserAlarmRepositoryTest {
     @Test
     void 회원_ID로_회원_알림_목록_조회_시_페이징과_ID_내림차순_정렬_검증() {
         // given
-        UserAlarm userAlarm1 = createUserAlarm(false);
+        UserAlarm userAlarm1 = createUserAlarm(alarm, false);
         userAlarmRepository.saveAndFlush(userAlarm1);
-        UserAlarm userAlarm2 = createUserAlarm(false);
+        UserAlarm userAlarm2 = createUserAlarm(alarm, false);
         userAlarmRepository.saveAndFlush(userAlarm2);
-        UserAlarm userAlarm3 = createUserAlarm(false);
+        UserAlarm userAlarm3 = createUserAlarm(alarm, false);
         userAlarmRepository.saveAndFlush(userAlarm3);
-        UserAlarm userAlarm4 = createUserAlarm(false);
+        UserAlarm userAlarm4 = createUserAlarm(alarm, false);
         userAlarmRepository.saveAndFlush(userAlarm4);
-        UserAlarm userAlarm5 = createUserAlarm(false);
+        UserAlarm userAlarm5 = createUserAlarm(alarm, false);
         userAlarmRepository.saveAndFlush(userAlarm5);
         em.clear();
 
@@ -235,27 +267,59 @@ public class UserAlarmRepositoryTest {
     }
 
     @Test
-    void 회원알림_확인_여부를_조회_검증() {
-        // given
-        UserAlarm userAlarm1 = createUserAlarm(false);
+    void 북마크_알림_목록_조회_시_페이징과_ID_내림차순_정렬과_타겟_종류_검증() {
+        News news1 = createNews();
+        News news2 = createNews();
+        em.clear();
+
+        Bookmark bookmark1 = createBookmark(news1);
+        Bookmark bookmark2 = createBookmark(news2);
+
+        Alarm alarm1 = createAlarm("제목1", "내용1", AlarmType.NEWS.toString(), bookmark1.getNews().getId());
+        Alarm alarm2 = createAlarm("제목2", "내용2", AlarmType.NEWS.toString(), bookmark2.getNews().getId());
+        Alarm alarm3 = createAlarm("제목3", "내용3", AlarmType.NEWS.toString(), bookmark1.getNews().getId());
+        Alarm alarm4 = createAlarm("제목4", "내용4", AlarmType.NEWS.toString(), bookmark2.getNews().getId());
+        Alarm alarm5 = createAlarm("제목5", "내용5", AlarmType.NEWS.toString(), bookmark1.getNews().getId());
+        em.clear();
+
+        UserAlarm userAlarm1 = createUserAlarm(alarm1, false);
         userAlarmRepository.saveAndFlush(userAlarm1);
-        UserAlarm userAlarm2 = createUserAlarm(true);
+        UserAlarm userAlarm2 = createUserAlarm(alarm2, false);
         userAlarmRepository.saveAndFlush(userAlarm2);
+        UserAlarm userAlarm3 = createUserAlarm(alarm3, false);
+        userAlarmRepository.saveAndFlush(userAlarm3);
+        UserAlarm userAlarm4 = createUserAlarm(alarm4, false);
+        userAlarmRepository.saveAndFlush(userAlarm4);
+        UserAlarm userAlarm5 = createUserAlarm(alarm5, false);
+        userAlarmRepository.saveAndFlush(userAlarm5);
         em.clear();
 
         // when
-        Boolean result1 = userAlarmRepository.existsByIdAndIsCheckedTrue(userAlarm1.getId());
-        Boolean result2 = userAlarmRepository.existsByIdAndIsCheckedTrue(userAlarm2.getId());
+        int pageSize = 3;
+        Pageable pageable = PageRequest.of(0, pageSize);
+        Page<UserAlarm> bookmarkAlarmPage = userAlarmRepository.findBookmarkAlarms(user.getId(), pageable);
+        List<UserAlarm> bookmarkAlarmList = bookmarkAlarmPage.getContent();
 
         // then
-        assertFalse(result1);
-        assertTrue(result2);
+        assertEquals(5, bookmarkAlarmPage.getTotalElements());
+        assertEquals(pageSize, bookmarkAlarmList.size());
+        assertEquals(userAlarm5.getId(), bookmarkAlarmList.get(0).getId());
+        assertEquals(userAlarm4.getId(), bookmarkAlarmList.get(1).getId());
+        assertEquals(userAlarm3.getId(), bookmarkAlarmList.get(2).getId());
+
+        assertEquals(AlarmType.NEWS, userAlarm5.getAlarm().getTargetType());
+        assertEquals(AlarmType.NEWS, userAlarm4.getAlarm().getTargetType());
+        assertEquals(AlarmType.NEWS, userAlarm3.getAlarm().getTargetType());
+
+        assertEquals(userAlarm5.getAlarm().getTargetId(), bookmark1.getNews().getId());
+        assertEquals(userAlarm4.getAlarm().getTargetId(), bookmark2.getNews().getId());
+        assertEquals(userAlarm3.getAlarm().getTargetId(), bookmark1.getNews().getId());
     }
 
     @Test
     void 확인하지_않은_회원알림을_확인_처리_검증() {
         // given
-        UserAlarm userAlarm = createUserAlarm(false);
+        UserAlarm userAlarm = createUserAlarm(alarm, false);
         userAlarmRepository.saveAndFlush(userAlarm);
         em.clear();
 

--- a/backend/src/test/java/com/tamnara/backend/alarm/repository/UserAlarmRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/repository/UserAlarmRepositoryTest.java
@@ -1,0 +1,273 @@
+package com.tamnara.backend.alarm.repository;
+
+import com.tamnara.backend.alarm.domain.Alarm;
+import com.tamnara.backend.alarm.domain.AlarmType;
+import com.tamnara.backend.alarm.domain.UserAlarm;
+import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.user.domain.Role;
+import com.tamnara.backend.user.domain.State;
+import com.tamnara.backend.user.domain.User;
+import com.tamnara.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@Import({JpaConfig.class, QuerydslConfig.class})
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class UserAlarmRepositoryTest {
+
+    @PersistenceContext private EntityManager em;
+
+    @Autowired private UserAlarmRepository userAlarmRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private AlarmRepository alarmRepository;
+
+    User user;
+    Alarm alarm;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        alarmRepository.deleteAll();
+        userAlarmRepository.deleteAll();
+
+        user = User.builder()
+                .email("이메일")
+                .password("비밀번호")
+                .username("이름")
+                .provider("LOCAL")
+                .providerId(null)
+                .role(Role.USER)
+                .state(State.ACTIVE)
+                .build();
+        userRepository.saveAndFlush(user);
+
+        alarm = new Alarm();
+        alarm.setTitle("제목");
+        alarm.setContent("내용");
+        alarm.setTargetType(AlarmType.NEWS);
+        alarm.setTargetId(1L);
+        alarmRepository.saveAndFlush(alarm);
+
+        em.clear();
+    }
+
+    private UserAlarm createUserAlarm(boolean isChecked) {
+        UserAlarm userAlarm = new UserAlarm();
+        userAlarm.setIsChecked(isChecked);
+        userAlarm.setCheckedAt(isChecked ? LocalDateTime.now() : null);
+        userAlarm.setUser(user);
+        userAlarm.setAlarm(alarm);
+        return userAlarm;
+    }
+
+    @Test
+    void 회원알림_생성_성공_검증() {
+        // given
+        UserAlarm userAlarm = createUserAlarm(false);
+        userAlarmRepository.save(userAlarm);
+
+        // when
+        Optional<UserAlarm> userAlarmOptional = userAlarmRepository.findById(userAlarm.getId());
+
+        // then
+        assertEquals(userAlarm.getId(), userAlarmOptional.get().getId());
+    }
+
+    @Test
+    void 회원알림_확인_여부_null_불가_검증() {
+        // given
+        UserAlarm userAlarm = createUserAlarm(true);
+
+        // when
+        userAlarm.setIsChecked(null);
+
+        // then
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            userAlarmRepository.saveAndFlush(userAlarm);
+        });
+    }
+
+    @Test
+    void 회원알림_확인_시간_null_가능_검증() {
+        // given
+        UserAlarm userAlarm = createUserAlarm(true);
+
+        // when
+        userAlarm.setCheckedAt(null);
+        UserAlarm savedUserAlarm = userAlarmRepository.saveAndFlush(userAlarm);
+        em.clear();
+
+        // then
+        assertNotNull(savedUserAlarm.getId());
+        assertNull(savedUserAlarm.getCheckedAt());
+    }
+
+    @Test
+    void 회원알림_회원_필드_null_불가_검증() {
+        // given
+        UserAlarm userAlarm = createUserAlarm(true);
+
+        // when
+        userAlarm.setUser(null);
+
+        // then
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            userAlarmRepository.saveAndFlush(userAlarm);
+        });
+    }
+
+    @Test
+    void 회원알림_알림_필드_null_불가_검증() {
+        // given
+        UserAlarm userAlarm = createUserAlarm(true);
+
+        // when
+        userAlarm.setAlarm(null);
+
+        // then
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            userAlarmRepository.saveAndFlush(userAlarm);
+        });
+    }
+
+    @Test
+    void 회원알림_확인_상태_업데이트_성공_검증() {
+        // given
+        UserAlarm userAlarm = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm);
+        em.clear();
+
+        // when
+        LocalDateTime now = LocalDateTime.now();
+        UserAlarm savedUserAlarm = userAlarmRepository.findById(userAlarm.getId()).get();
+        savedUserAlarm.setIsChecked(true);
+        savedUserAlarm.setCheckedAt(now);
+        UserAlarm updatedUserAlarm = userAlarmRepository.saveAndFlush(savedUserAlarm);
+        em.clear();
+
+        // then
+        assertEquals(userAlarm.getId(), updatedUserAlarm.getId());
+        assertTrue(updatedUserAlarm.getIsChecked());
+        assertEquals(now, updatedUserAlarm.getCheckedAt());
+    }
+
+    @Test
+    void 회원알림_삭제_성공_검증() {
+        // given
+        UserAlarm userAlarm = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm);
+        em.clear();
+
+        // when
+        userAlarmRepository.delete(userAlarm);
+
+        // then
+        assertFalse(userAlarmRepository.findById(userAlarm.getId()).isPresent());
+    }
+
+    @Test
+    void 단일_회원알림_조회_성공_검증() {
+        // given
+        UserAlarm userAlarm = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm);
+        em.clear();
+
+        // when
+        UserAlarm findUserAlarm = userAlarmRepository.findById(userAlarm.getId()).get();
+
+        // then
+        assertEquals(userAlarm.getId(), findUserAlarm.getId());
+    }
+
+    @Test
+    void 회원_ID로_회원_알림_목록_조회_시_페이징과_ID_내림차순_정렬_검증() {
+        // given
+        UserAlarm userAlarm1 = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm1);
+        UserAlarm userAlarm2 = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm2);
+        UserAlarm userAlarm3 = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm3);
+        UserAlarm userAlarm4 = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm4);
+        UserAlarm userAlarm5 = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm5);
+        em.clear();
+
+        // when
+        int pageSize = 3;
+        Pageable pageable = PageRequest.of(0, pageSize);
+        Page<UserAlarm> userAlarmPage = userAlarmRepository.findByUserIdOrderByIdDesc(user.getId(), pageable);
+        List<UserAlarm> userAlarmList = userAlarmPage.getContent();
+
+        // then
+        assertEquals(5, userAlarmPage.getTotalElements());
+        assertEquals(pageSize, userAlarmList.size());
+        assertEquals(userAlarm5.getId(), userAlarmList.get(0).getId());
+        assertEquals(userAlarm4.getId(), userAlarmList.get(1).getId());
+        assertEquals(userAlarm3.getId(), userAlarmList.get(2).getId());
+    }
+
+    @Test
+    void 회원알림_확인_여부를_조회_검증() {
+        // given
+        UserAlarm userAlarm1 = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm1);
+        UserAlarm userAlarm2 = createUserAlarm(true);
+        userAlarmRepository.saveAndFlush(userAlarm2);
+        em.clear();
+
+        // when
+        Boolean result1 = userAlarmRepository.existsByIdAndIsCheckedTrue(userAlarm1.getId());
+        Boolean result2 = userAlarmRepository.existsByIdAndIsCheckedTrue(userAlarm2.getId());
+
+        // then
+        assertFalse(result1);
+        assertTrue(result2);
+    }
+
+    @Test
+    void 확인하지_않은_회원알림을_확인_처리_검증() {
+        // given
+        UserAlarm userAlarm = createUserAlarm(false);
+        userAlarmRepository.saveAndFlush(userAlarm);
+        em.clear();
+
+        // when
+        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        userAlarmRepository.checkUserAlarm(userAlarm.getId(), now);
+        em.clear();
+
+        // then
+        UserAlarm savedUserAlarm = userAlarmRepository.findById(userAlarm.getId()).get();
+        assertEquals(userAlarm.getId(), savedUserAlarm.getId());
+        assertTrue(savedUserAlarm.getIsChecked());
+        assertEquals(now, savedUserAlarm.getCheckedAt());
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/alarm/service/AlarmSchedulerServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/service/AlarmSchedulerServiceImplTest.java
@@ -1,0 +1,26 @@
+package com.tamnara.backend.alarm.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class AlarmSchedulerServiceImplTest {
+
+    @Mock private AlarmService alarmService;
+    @InjectMocks private AlarmSchedulerServiceImpl alarmSchedulerService;
+
+    @Test
+    void 오래된_알림_일괄_삭제_검증() {
+        // when
+        alarmSchedulerService.deleteOldAlarms();
+
+        // then
+        verify(alarmService, times(1)).deleteAlarms();
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/alarm/service/AlarmServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/service/AlarmServiceImplTest.java
@@ -1,0 +1,283 @@
+package com.tamnara.backend.alarm.service;
+
+import com.tamnara.backend.alarm.constant.AlarmServiceConstant;
+import com.tamnara.backend.alarm.domain.Alarm;
+import com.tamnara.backend.alarm.domain.AlarmType;
+import com.tamnara.backend.alarm.domain.UserAlarm;
+import com.tamnara.backend.alarm.dto.response.AlarmListResponse;
+import com.tamnara.backend.alarm.repository.AlarmRepository;
+import com.tamnara.backend.alarm.repository.UserAlarmRepository;
+import com.tamnara.backend.global.constant.ResponseMessage;
+import com.tamnara.backend.user.domain.Role;
+import com.tamnara.backend.user.domain.State;
+import com.tamnara.backend.user.domain.User;
+import com.tamnara.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class AlarmServiceImplTest {
+
+    @Mock AlarmRepository alarmRepository;
+    @Mock UserAlarmRepository userAlarmRepository;
+    @Mock UserRepository userRepository;
+
+    @InjectMocks private AlarmServiceImpl alarmServiceImpl;
+
+    User user;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        lenient().when(user.getId()).thenReturn(1L);
+        lenient().when(user.getEmail()).thenReturn("이메일");
+        lenient().when(user.getPassword()).thenReturn("비밀번호");
+        lenient().when(user.getUsername()).thenReturn("이름");
+        lenient().when(user.getProvider()).thenReturn("LOCAL");
+        lenient().when(user.getProviderId()).thenReturn(null);
+        lenient().when(user.getRole()).thenReturn(Role.USER);
+        lenient().when(user.getState()).thenReturn(State.ACTIVE);
+    }
+
+    private Alarm createAlarm(String title, String content, String targetType, Long targetId) {
+        Alarm alarm = new Alarm();
+        alarm.setTitle(title);
+        alarm.setContent(content);
+        alarm.setTargetType(targetType == null ? null : AlarmType.valueOf(targetType));
+        alarm.setTargetId(targetId);
+
+        return alarm;
+    }
+
+    private UserAlarm createUserAlarm(boolean isChecked, Alarm alarm) {
+        UserAlarm userAlarm = new UserAlarm();
+        userAlarm.setIsChecked(isChecked);
+        userAlarm.setCheckedAt(isChecked ? LocalDateTime.now() : null);
+        userAlarm.setUser(user);
+        userAlarm.setAlarm(alarm);
+        return userAlarm;
+    }
+
+    @Test
+    void 전체_알림_목록_조회_검증() {
+        // given
+        Alarm alarm1 = createAlarm("제목1", "내용1", AlarmType.NEWS.toString(), 1L);
+        Alarm alarm2 = createAlarm("제목2", "내용2", AlarmType.POLL.toString(), 1L);
+        Alarm alarm3 = createAlarm("제목3", "내용3", null, null);
+        Alarm alarm4 = createAlarm("제목4", "내용4", AlarmType.NEWS.toString(), 2L);
+        Alarm alarm5 = createAlarm("제목5", "내용5", AlarmType.POLL.toString(), 2L);
+
+        UserAlarm userAlarm1 = createUserAlarm(true, alarm1);
+        UserAlarm userAlarm2 = createUserAlarm(false, alarm2);
+        UserAlarm userAlarm3 = createUserAlarm(false, alarm3);
+        UserAlarm userAlarm4 = createUserAlarm(false, alarm4);
+        UserAlarm userAlarm5 = createUserAlarm(false, alarm5);
+
+        List<UserAlarm> userAlarmList = List.of(userAlarm1, userAlarm2, userAlarm3, userAlarm4, userAlarm5);
+        Page<UserAlarm> userAlarmPage = new PageImpl<>(userAlarmList);
+
+        Pageable pageable = PageRequest.of(0, AlarmServiceConstant.ALARM_LIST_SIZE);
+        when(userAlarmRepository.findByUserIdOrderByIdDesc(user.getId(), pageable)).thenReturn(userAlarmPage);
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
+
+        // when
+        AlarmListResponse response = alarmServiceImpl.getAllAlarmPageByUserId(user.getId());
+
+        // then
+        assertEquals(AlarmServiceConstant.ALARM_RESPONSE_TYPE_ALL, response.getType());
+        assertEquals(5, response.getAlarms().size());
+        assertEquals(response.getAlarms().get(0).getId(), alarm5.getId());
+        assertEquals(response.getAlarms().get(1).getId(), alarm4.getId());
+        assertEquals(response.getAlarms().get(2).getId(), alarm3.getId());
+        assertEquals(response.getAlarms().get(3).getId(), alarm2.getId());
+        assertEquals(response.getAlarms().get(4).getId(), alarm1.getId());
+    }
+
+    @Test
+    void 전체_알림_목록_조회_시_알림이_존재하지_않아도_성공_검증() {
+        // given
+        List<UserAlarm> userAlarmList = List.of();
+        Page<UserAlarm> userAlarmPage = new PageImpl<>(userAlarmList);
+
+        Pageable pageable = PageRequest.of(0, AlarmServiceConstant.ALARM_LIST_SIZE);
+        when(userAlarmRepository.findByUserIdOrderByIdDesc(user.getId(), pageable)).thenReturn(userAlarmPage);
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
+
+        // when
+        AlarmListResponse response = alarmServiceImpl.getAllAlarmPageByUserId(user.getId());
+
+        // then
+        assertEquals(AlarmServiceConstant.ALARM_RESPONSE_TYPE_ALL, response.getType());
+        assertEquals(0, response.getAlarms().size());
+    }
+
+    @Test
+    void 전체_알림_목록_조회_시_회원이_존재하지_않으면_예외_처리_검증() {
+        // given
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        // when
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            alarmServiceImpl.getAllAlarmPageByUserId(user.getId());
+        });
+
+        // then
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals(ResponseMessage.USER_NOT_FOUND, exception.getReason());;
+    }
+
+    @Test
+    void 북마크_알림_목록_조회_검증() {
+        // given
+        Alarm alarm1 = createAlarm("제목1", "내용1", AlarmType.NEWS.toString(), 1L);
+        Alarm alarm2 = createAlarm("제목2", "내용2", AlarmType.NEWS.toString(), 1L);
+        Alarm alarm3 = createAlarm("제목3", "내용3", AlarmType.NEWS.toString(), 2L);
+        Alarm alarm4 = createAlarm("제목4", "내용4", AlarmType.NEWS.toString(), 2L);
+        Alarm alarm5 = createAlarm("제목5", "내용5", AlarmType.NEWS.toString(), 3L);
+
+        UserAlarm userAlarm1 = createUserAlarm(true, alarm1);
+        UserAlarm userAlarm2 = createUserAlarm(false, alarm2);
+        UserAlarm userAlarm3 = createUserAlarm(false, alarm3);
+        UserAlarm userAlarm4 = createUserAlarm(false, alarm4);
+        UserAlarm userAlarm5 = createUserAlarm(false, alarm5);
+
+        List<UserAlarm> userAlarmList = List.of(userAlarm1, userAlarm2, userAlarm3, userAlarm4, userAlarm5);
+        Page<UserAlarm> userAlarmPage = new PageImpl<>(userAlarmList);
+
+        Pageable pageable = PageRequest.of(0, AlarmServiceConstant.ALARM_LIST_SIZE);
+        when(userAlarmRepository.findBookmarkAlarms(user.getId(), pageable)).thenReturn(userAlarmPage);
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
+
+        // when
+        AlarmListResponse response = alarmServiceImpl.getBookmarkAlarmPageByUserId(user.getId());
+
+        // then
+        assertEquals(AlarmServiceConstant.ALARM_RESPONSE_TYPE_BOOKMARK, response.getType());
+        assertEquals(5, response.getAlarms().size());
+        assertEquals(response.getAlarms().get(0).getId(), alarm5.getId());
+        assertEquals(response.getAlarms().get(1).getId(), alarm4.getId());
+        assertEquals(response.getAlarms().get(2).getId(), alarm3.getId());
+        assertEquals(response.getAlarms().get(3).getId(), alarm2.getId());
+        assertEquals(response.getAlarms().get(4).getId(), alarm1.getId());
+    }
+
+    @Test
+    void 북마크_알림_목록_조회_시_알림이_존재하지_않아도_성공_검증() {
+        // given
+        List<UserAlarm> userAlarmList = List.of();
+        Page<UserAlarm> userAlarmPage = new PageImpl<>(userAlarmList);
+
+        Pageable pageable = PageRequest.of(0, AlarmServiceConstant.ALARM_LIST_SIZE);
+        when(userAlarmRepository.findBookmarkAlarms(user.getId(), pageable)).thenReturn(userAlarmPage);
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
+
+        // when
+        AlarmListResponse response = alarmServiceImpl.getBookmarkAlarmPageByUserId(user.getId());
+
+        // then
+        assertEquals(AlarmServiceConstant.ALARM_RESPONSE_TYPE_BOOKMARK, response.getType());
+        assertEquals(0, response.getAlarms().size());
+    }
+
+    @Test
+    void 북마크_알림_목록_조회_시_회원이_존재하지_않으면_예외_처리_검증() {
+        // given
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        // when
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            alarmServiceImpl.getBookmarkAlarmPageByUserId(user.getId());
+        });
+
+        // then
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals(ResponseMessage.USER_NOT_FOUND, exception.getReason());;
+    }
+
+    @Test
+    void 미확인_알림_확인_처리_검증() {
+        // given
+        Alarm alarm = createAlarm("제목1", "내용1", AlarmType.NEWS.toString(), 1L);
+        UserAlarm userAlarm = createUserAlarm(false, alarm);
+
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
+        when(userAlarmRepository.findById(any(Long.class))).thenReturn(Optional.of(userAlarm));
+
+        // when
+        Long alarmId = alarmServiceImpl.checkUserAlarm(1L, user.getId());
+
+        // then
+        assertEquals(alarmId, userAlarm.getId());
+    }
+
+    @Test
+    void 확인한_알림_확인_처리_검증() {
+        // given
+        Alarm alarm = createAlarm("제목1", "내용1", AlarmType.NEWS.toString(), 1L);
+        UserAlarm userAlarm = createUserAlarm(true, alarm);
+
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(user));
+        when(userAlarmRepository.findById(any(Long.class))).thenReturn(Optional.of(userAlarm));
+
+        // when
+        Long alarmId = alarmServiceImpl.checkUserAlarm(1L, user.getId());
+
+        // then
+        assertEquals(alarmId, userAlarm.getId());
+    }
+
+    @Test
+    void 알림_확인_처리_시_회원이_존재하지_않으면_예외_처리_검증() {
+        // given
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+        // when
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
+            alarmServiceImpl.getAllAlarmPageByUserId(user.getId());
+        });
+
+        // then
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals(ResponseMessage.USER_NOT_FOUND, exception.getReason());;
+    }
+
+    @Test
+    void 오래된_알림들_일괄_삭제_검증() {
+        // given
+        LocalDateTime cutoff = LocalDateTime.now()
+                .minusDays(AlarmServiceConstant.ALARM_DELETE_DAYS).truncatedTo(ChronoUnit.SECONDS);
+
+        // when
+        alarmServiceImpl.deleteAlarms();
+
+        // then
+        verify(alarmRepository, times(1)).deleteAllOlderThan(argThat(actualCutoff ->
+                actualCutoff.truncatedTo(ChronoUnit.SECONDS).equals(cutoff)
+        ));
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
closes #238 

<br/>

## 작업 내용
- [x] 알림 도메인 구현
- [x] 알림 리포지토리 구현
- [x] 알림 서비스 구현
- [x] 알림 컨트롤러 구현
- [x] 오래된 알림 삭제 스케줄링 메서드 구현

<br/>

## 상세 내용
### 알림 도메인 추가
- **작업한 파일:** `alarm.domain.Alarm`, `alarm.domain.AlarmType`, `alarm.domain.UserAlarm`
- **작업한 내용:**
    - `alarms` 테이블에 해당하는 `Alarm` 엔티티 추가
    - Alarm 엔티티의 `targetType` 필드에 해당하는 enum `AlarmType` 추가
    - `user_alarm` 테이블에 해당하는 `UserAlarm` 엔티티 추가
- **테스트 목록**
    - Alarm 도메인 단위 테스트
        - 알림 기본값 초기화 검증
        - 알림 제목과 내용과 타겟종류와 타겟ID 설정 검증
        - ID가 동일하면 동일한 알림 검증
        - 알림 타겟 종류의 전체 정의값 검증
        - 문자열로부터 enum 변환 검증
        - 잘못된 문자열이 enum 변환에 실패 검증
   - UserAlarm 도메인 단위 테스트
        - 회원알림 기본값 초기화 검증
        - 회원알림 회원과 알림 설정 검증
        - 회원알림 확인 여부와 확인 시간 설정 검증
        - ID가 동일하면 동일한 회원알림 검증

<br/>

### 알림 리포지토리 추가
- **작업한 파일:** `alarm.repository.AlarmRepository`, `alarm.repository.UserAlarmRepository`
- **작업한 내용:**
    - `AlarmRepository` 리포지토리 추가
        - 타겟 종류와 타겟 ID로 알림 목록을 ID 내림차순으로 정렬하여 조회
        - 기준보다 오래된 알림들을 일괄 삭제
    - `UserAlarmRepository` 리포지토리 추가
        - 회원 ID로 회원알림 목록 ID 내림차순 조회 메서드 추가
        - 특정 회원알림이 확인되었는지 여부 조회 메서드 추가
        - 회원알림 확인 처리 메서드 추가
- **테스트 목록**
    - AlarmRepository 단위 테스트
        - 알림 생성 성공 검증
        - 알림 제목 null 불가 검증
        - 알림 제목 길이 제약 검증
        - 알림 내용 null 불가 검증
        - 알림 내용 길이 제약 검증
        - 알림 타겟 종류 null 가능 검증
        - 알림 타겟 ID null 가능 검증
        - 알림 생성일자 자동 생성 검증
        - 알림 수정 성공 검증
        - 알림 삭제 성공 검증
        - 알림 삭제 시 연관된 회원알림 CASCADE 검증
        - 단일 알림 조회 성공 검증
        - 타겟 종류와 타겟 ID로 알림 목록 조회 시 ID 내림차순 정렬 검증
        - 생성일자가 기준보다 오래된 알림 일괄 삭제 검증
   - UserAlarmRepository 단위 테스트
        - 회원알림 생성 성공 검증
        - 회원알림 확인 여부 null 불가 검증
        - 회원알림 확인 시간 null 가능 검증
        - 회원알림 회원 필드 null 불가 검증
        - 회원알림 알림 필드 null 불가 검증
        - 회원알림 확인 상태 업데이트 성공 검증
        - 회원알림 삭제 성공 검증
        - 단일 회원알림 조회 성공 검증
        - 회원 ID로 회원 알림 목록 조회 시 페이징과 ID 내림차순 정렬 검증
        - 회원알림 확인 여부를 조회 검증
        - 확인하지 않은 회원알림을 확인 처리 검증

<br/>

### 알림 서비스 추가
- **작업한 파일:** `alarm.service.AlarmService`, `alarm.service.AlarmServiceImpl`
- **작업한 내용:**
    - 전체 알림 목록 조회 메서드 추가
    - 북마크 알림 목록 조회 메서드 추가
    - 알림 확인 처리 메서드 추가
    - 오래된 알림 일괄 삭제 메서드 추가
- **테스트 목록**
    - 전체 알림 목록 조회 검증
    - 전체 알림 목록 조회 시 알림이 존재하지 않아도 성공 검증
    - 전체 알림 목록 조회 시 회원이 존재하지 않으면 예외 처리 검증
    - 북마크 알림 목록 조회 검증
    - 북마크 알림 목록 조회 시 알림이 존재하지 않아도 성공 검증
    - 북마크 알림 목록 조회 시 회원이 존재하지 않으면 예외 처리 검증
    - 미확인 알림 확인 처리 검증
    - 확인한 알림 확인 처리 검증
    - 알림 처리 시 회원이 존재하지 않으면 예외 처리 검증
    - 오래된 알림들 일괄 삭제 검증

<br/>

### 알림 컨트롤러 API 추가
- **작업한 파일:** `alarm.controller.AlarmController`
- **작업한 내용:**
    - 알림 목록 조회 API 추가
    - 개별 알림 확인 API 추가
- **테스트 목록**
    - 로그아웃 상태에서 알림 카드 목록 조회 불가 검증
    - 로그인 상태에서 알림 카드 목록 조회 검증
    - 로그아웃 상태에서 단일 알림 확인 불가 검증
    - 로그인 상태에서 단일 알림 확인 검증

<br/>

### 오래된 알림 삭제 스케줄링 메서드 구현
- **작업한 파일:** `alarm.service.AlarmSchedulerService`
- **작업한 내용:** 매일 오전 9시에 오래된 알림 일괄 삭제