### PR TITLE
chore: CORS 설정 방식 롤백 (fff3703) 및 인증 에러 반환 수동 처리

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.tamnara.backend.global.config;
 
 import com.tamnara.backend.global.jwt.JwtProvider;
+import com.tamnara.backend.global.security.CustomAuthenticationEntryPoint;
 import com.tamnara.backend.global.security.JwtAuthenticationFilter;
 import com.tamnara.backend.user.security.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
     private final UserDetailsServiceImpl userDetailsService;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
     private final String FRONTEND_BASE_URL_LOCAL = "http://localhost:5173";
     @Value("${FE_BASE_URL}") private String FRONTEND_BASE_URL_PROD;
@@ -43,6 +45,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryPoint))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/backend/src/main/java/com/tamnara/backend/global/security/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/tamnara/backend/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.tamnara.backend.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tamnara.backend.global.constant.ResponseMessage;
+import com.tamnara.backend.global.dto.WrappedDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(); // 수동 생성 or 주입
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        WrappedDTO<Object> body = new WrappedDTO<>(false, ResponseMessage.USER_NOT_CERTIFICATION, null);
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
closes #280 

<br/>

## 작업 내용
- [x] CORS 설정을 configurationSource 방식으로 명시적 주입으로 전환
- [x] 인증 실패 시 401 응답 및 WrappedDTO 형식으로 메시지 반환

<br/>

## 상세 내용
### CORS 설정에서 configure → configurationSource 방식으로 전환
**작업한 파일:** `global.config.SecurityConfig`
- `.cors(cors -> cors.configure(http))` 방식 제거
- `.cors(cors -> cors.configurationSource(corsConfigurationSource()))` 적용

<br/>

### 인증 실패 시 401 응답 및 WrappedDTO 형식으로 메시지 반환
**작업한 파일:** `global.config.SecurityConfig`, `global.security.CustomAuthenticationEntryPoint`
- 인증 실패 시 401 상태 코드와 함께 JSON 응답 반환
- 응답 형식에 WrappedDTO 사용