### PR TITLE
feat: 투표 `state` 필드 값 자동 변경 메서드 및 수동 스케줄 API 구현

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/poll/constant/PollResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/constant/PollResponseMessage.java
@@ -14,4 +14,5 @@ public class PollResponseMessage {
     public static final String POLL_OR_OPTION_NOT_FOUND = "요청하신 투표 또는 선택지를 찾을 수 없습니다.";
     public static final String POLL_INVALID_SELECTION_COUNT = "응답 수가 올바르지 않습니다.";
     public static final String POLL_ALREADY_VOTED = "이미 투표하셨습니다.";
+    public static final String PUBLISHED_POLL_ALREADY_EXISTS = "이미 공개 중인 투표가 있어 새로운 투표를 PUBLISH할 수 없습니다.";
 }

--- a/backend/src/main/java/com/tamnara/backend/poll/constant/PollResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/constant/PollResponseMessage.java
@@ -2,6 +2,7 @@ package com.tamnara.backend.poll.constant;
 
 public class PollResponseMessage {
     public static final String POLL_CREATED = "투표가 성공적으로 생성되었습니다.";
+    public static final String POLL_SCHEDULED = "투표가 성공적으로 SCHEDULED 처리되었습니다.";
     public static final String POLL_OK = "요청하신 정보를 성공적으로 불러왔습니다.";
     public static final String VOTE_SUCCESS = "투표가 완료되었습니다.";
 

--- a/backend/src/main/java/com/tamnara/backend/poll/domain/Poll.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/domain/Poll.java
@@ -40,10 +40,15 @@ public class Poll {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(length = 20, nullable = false)
-    private PollState state;
+    private PollState state = PollState.DRAFT;
 
     @OneToMany(mappedBy = "poll", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PollOption> options;
+
+    public void changeState(PollState state) {
+        this.state = state;
+    }
 }

--- a/backend/src/main/java/com/tamnara/backend/poll/repository/PollRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/repository/PollRepository.java
@@ -10,4 +10,7 @@ import java.util.List;
 public interface PollRepository extends JpaRepository<Poll, Long> {
     List<Poll> findByState(PollState state);
     List<Poll> findByEndAtAfter(LocalDateTime now);
+    List<Poll> findByStateAndEndAtBefore(PollState state, LocalDateTime now);
+    List<Poll> findByStateAndStartAtBeforeAndEndAtAfter(PollState state, LocalDateTime nowForStart, LocalDateTime nowForEnd);
+    boolean existsByState(PollState state);
 }

--- a/backend/src/main/java/com/tamnara/backend/poll/scheduler/PollStateScheduler.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/scheduler/PollStateScheduler.java
@@ -1,0 +1,49 @@
+package com.tamnara.backend.poll.scheduler;
+
+import com.tamnara.backend.poll.domain.Poll;
+import com.tamnara.backend.poll.domain.PollState;
+import com.tamnara.backend.poll.repository.PollRepository;
+import com.tamnara.backend.poll.service.PollService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PollStateScheduler {
+
+    private final PollRepository pollRepository;
+    private final PollService pollService;
+
+    @Scheduled(cron = "0 5/10 * * * *")
+    public void updatePollStates() {
+        LocalDateTime now = LocalDateTime.now();
+        log.info("[스케줄러] 투표 상태 자동 전환을 시작합니다.");
+
+        // PUBLISHED → DELETED (endAt 지난 투표 모두 삭제 처리)
+        List<Poll> toDelete = pollRepository.findByStateAndEndAtBefore(PollState.PUBLISHED, now);
+        if (!toDelete.isEmpty()) {
+            toDelete.forEach(pollService::deletePoll);
+            log.info("[스케줄러] {}개의 투표를 DELETED 처리했습니다.", toDelete.size());
+        }
+
+        // SCHEDULED → PUBLISHED (가장 이른 startAt 우선)
+        List<Poll> scheduled = pollRepository
+                .findByStateAndStartAtBeforeAndEndAtAfter(PollState.SCHEDULED, now, now);
+
+        scheduled.stream()
+                .min(Comparator.comparing(Poll::getStartAt))
+                .ifPresent(poll -> {
+                    pollService.publishPoll(poll);
+                    log.info("[스케줄러] 투표(ID={})를 PUBLISHED 처리했습니다.", poll.getId());
+                });
+
+        log.info("[스케줄러] 투표 상태 자동 전환을 완료했습니다.");
+    }
+}

--- a/backend/src/main/java/com/tamnara/backend/poll/service/PollService.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/service/PollService.java
@@ -6,7 +6,10 @@ import com.tamnara.backend.poll.repository.PollRepository;
 import com.tamnara.backend.poll.repository.PollOptionRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -41,5 +44,23 @@ public class PollService {
 
     public Poll getPollById(Long pollId) {
         return pollRepository.findById(pollId).orElse(null);
+    }
+
+    @Transactional
+    public void publishPoll(Poll poll) {
+        if (pollRepository.existsByState(PollState.PUBLISHED)) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    PUBLISHED_POLL_ALREADY_EXISTS
+            );
+        }
+        poll.changeState(PollState.PUBLISHED);
+        pollRepository.save(poll);
+    }
+
+    @Transactional
+    public void deletePoll(Poll poll) {
+        poll.changeState(PollState.DELETED);
+        pollRepository.save(poll);
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/poll/service/PollService.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/service/PollService.java
@@ -47,6 +47,12 @@ public class PollService {
     }
 
     @Transactional
+    public void schedulePoll(Poll poll) {
+        poll.changeState(PollState.SCHEDULED);
+        pollRepository.save(poll);
+    }
+
+    @Transactional
     public void publishPoll(Poll poll) {
         if (pollRepository.existsByState(PollState.PUBLISHED)) {
             throw new ResponseStatusException(


### PR DESCRIPTION
### 변경 사항

- **`PollResponseMessage`**: 
  - `POLL_SCHEDULED` 메시지 추가: "투표가 성공적으로 SCHEDULED 처리되었습니다."
  - 기존 메시지들이 업데이트되었습니다.

- **`PollController`**:
  - `@PostMapping("/{pollId}/schedule")` 엔드포인트 추가: 관리자가 특정 투표를 `SCHEDULED` 상태로 전환할 수 있도록 처리
  - 사용자 상태가 비활성화(`INACTIVE`)되거나 존재하지 않으면 각각 **403 Forbidden** 또는 **404 Not Found** 응답 반환
  - 성공 시 **200 OK**와 함께 `POLL_SCHEDULED` 메시지를 반환

- **`Poll` 엔티티**:
  - `PollState` 필드의 초기값 `DRAFT`를 `@Builder.Default`로 처리
  - `changeState(PollState state)` 메서드 추가: 투표 상태 변경 로직 캡슐화

- **`PollRepository`**:
  - 새로운 쿼리 메서드 `findByStateAndStartAtBeforeAndEndAtAfter` 추가: `SCHEDULED` 상태인 투표 중 `startAt`은 지나고 `endAt`은 아직 지나지 않은 투표 조회

- **`PollStateScheduler`**:
  - `@Scheduled(cron = "0 5/10 * * * *")` 스케줄러 추가: 
    - `PUBLISHED` 상태인 투표가 `endAt`을 지나면 `DELETED`로 변경
    - `SCHEDULED` 상태인 투표 중 가장 이른 `startAt`이 지난 투표를 `PUBLISHED`로 자동 전환

- **`PollService`**:
  - `schedulePoll`, `publishPoll`, `deletePoll` 메서드 추가: 투표 상태 전환 및 상태 변경에 따른 데이터베이스 저장 처리

### 주요 변경 내용

- **`PollState`** 와 관련된 상태 관리가 추가되었습니다. 
- 관리자는 `/polls/{pollId}/schedule` API를 통해 `SCHEDULED` 상태로 투표를 전환할 수 있습니다.
- `PollStateScheduler`는 주기적으로 투표 상태를 자동으로 업데이트하여 만료된 투표를 `DELETED` 상태로 전환하고, 시작 시간이 지난 투표를 `PUBLISHED` 상태로 전환합니다.
- 기존 `Poll` 엔티티는 상태 변경을 위한 `changeState` 메서드를 추가하여 상태 변경 로직을 중앙집중화했습니다.

### 추가 사항

- **기능**: 투표 상태 전환, 자동 상태 전환
- **사용자 권한**: `ROLE_ADMIN` 권한만 접근 가능
