### PR TITLE
refactor: 비동기 설정을 Config 클래스로 분리하여 책임 분리

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/BackendApplication.java
+++ b/backend/src/main/java/com/tamnara/backend/BackendApplication.java
@@ -2,10 +2,8 @@ package com.tamnara.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
-@EnableAsync
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/tamnara/backend/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.tamnara.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/backend/src/main/java/com/tamnara/backend/global/security/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/tamnara/backend/global/security/CustomAuthenticationEntryPoint.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private final ObjectMapper objectMapper = new ObjectMapper(); // 수동 생성 or 주입
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public void commence(


### PR DESCRIPTION
## 연관된 이슈
#294 

<br/>

## 작업 내용
- [x] CustomAuthenticationEntryPoint 내 불필요한 주석 제거
- [x] `@EnableAsync` 어노테이션을 메인 클래스에서 설정 클래스 AsyncConfig로 분리

<br/>

## 상세 내용
### 비동기 설정을 Config 클래스로 분리하여 책임 분리
- **작업한 파일:** `BackendApplication`, `global.config.AsyncConfig`
   - `@EnableAsync` 어노테이션을 메인 클래스에서 제거
   - 비동기 설정 클래스를 추가하여 `@EnableAsync` 어노테이션 적용
```java
@Configuration
@EnableAsync
public class AsyncConfig {
}
```