### PR TITLE
feat:  단위 테스트 추가 for PollService, VoteService, and VoteStatisticsService

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/poll/dto/PollCreateRequest.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/dto/PollCreateRequest.java
@@ -2,12 +2,14 @@ package com.tamnara.backend.poll.dto;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@Builder
 public class PollCreateRequest {
 
     @NotBlank

--- a/backend/src/main/java/com/tamnara/backend/poll/dto/PollOptionCreateRequest.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/dto/PollOptionCreateRequest.java
@@ -1,9 +1,13 @@
 package com.tamnara.backend.poll.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class PollOptionCreateRequest {
 
     @NotBlank(message = "옵션 제목은 필수입니다.")

--- a/backend/src/main/java/com/tamnara/backend/poll/service/PollService.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/service/PollService.java
@@ -43,7 +43,8 @@ public class PollService {
     }
 
     public Poll getPollById(Long pollId) {
-        return pollRepository.findById(pollId).orElse(null);
+        return pollRepository.findById(pollId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, POLL_NOT_FOUND));
     }
 
     @Transactional

--- a/backend/src/test/java/com/tamnara/backend/poll/service/PollServiceTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/service/PollServiceTest.java
@@ -1,0 +1,196 @@
+package com.tamnara.backend.poll.service;
+
+import com.tamnara.backend.poll.domain.*;
+import com.tamnara.backend.poll.dto.PollCreateRequest;
+import com.tamnara.backend.poll.dto.PollOptionCreateRequest;
+import com.tamnara.backend.poll.repository.PollRepository;
+import com.tamnara.backend.poll.repository.PollOptionRepository;
+import com.tamnara.backend.poll.util.PollCreateRequestTestBuilder;
+import com.tamnara.backend.poll.util.PollOptionTestBuilder;
+import com.tamnara.backend.poll.util.PollTestBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.tamnara.backend.poll.constant.PollResponseMessage.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PollServiceTest {
+
+    @Mock
+    private PollRepository pollRepository;
+
+    @Mock
+    private PollOptionRepository pollOptionRepository;
+
+    @InjectMocks
+    private PollService pollService;
+
+    private Poll poll;
+    private PollOption option;
+
+    @BeforeEach
+    void setUp() {
+        poll = PollTestBuilder.defaultPoll();
+        option = PollOptionTestBuilder.defaultOption(poll);
+    }
+
+    @Test
+    @DisplayName("createPoll 실행에 성공한다")
+    void createPoll_success() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        PollCreateRequest request = PollCreateRequestTestBuilder.build(
+                "Test Poll", 1, 2, now.minusDays(1), now.plusDays(1),
+                Arrays.asList(
+                        new PollOptionCreateRequest("Option 1", "url1"),
+                        new PollOptionCreateRequest("Option 2", "url2")
+                ));
+
+        when(pollRepository.save(Mockito.any(Poll.class))).thenReturn(poll);
+        when(pollOptionRepository.saveAll(Mockito.anyList())).thenReturn(Arrays.asList(option));
+
+        // when
+        Long pollId = pollService.createPoll(request);
+
+        // then
+        assertThat(pollId).isEqualTo(poll.getId());
+        Mockito.verify(pollRepository, Mockito.times(1)).save(Mockito.any(Poll.class));
+        Mockito.verify(pollOptionRepository, Mockito.times(1)).saveAll(Mockito.anyList());
+    }
+
+    @Test
+    @DisplayName("createPoll 실행에서 minChoices가 maxChoices보다 큰 경우 400 에러가 발생한다")
+    void createPoll_throwsException_whenMinChoicesExceedsMaxChoices() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        PollCreateRequest request = PollCreateRequestTestBuilder.build(
+                "Test Poll", 5, 3, now.minusDays(1), now.plusDays(1),
+                Arrays.asList(
+                        new PollOptionCreateRequest("Option 1", "url1"),
+                        new PollOptionCreateRequest("Option 2", "url2")
+                ));
+
+        // when & then
+        assertThatThrownBy(() -> pollService.createPoll(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(MIN_CHOICES_EXCEED_MAX);
+    }
+
+    @Test
+    @DisplayName("createPoll 실행에서 start_at이 end_at보다 나중인 경우 400 에러가 발생한다")
+    void createPoll_throwsException_whenStartDateIsAfterEndDate() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        PollCreateRequest request = PollCreateRequestTestBuilder.build(
+                "Test Poll", 1, 2, now.plusDays(1), now.minusDays(1),
+                Arrays.asList(
+                        new PollOptionCreateRequest("Option 1", "url1"),
+                        new PollOptionCreateRequest("Option 2", "url2")
+                ));
+
+        // when & then
+        assertThatThrownBy(() -> pollService.createPoll(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(START_DATE_LATER_THAN_END_DATE);
+    }
+
+    @Test
+    @DisplayName("getPollById 실행에서 정상적으로 Poll이 반환된다")
+    void getPollById_returnsPoll_whenPollExists() {
+        // given
+        when(pollRepository.findById(1L)).thenReturn(Optional.of(poll));
+
+        // when
+        Poll result = pollService.getPollById(1L);
+
+        // then
+        assertThat(result).isEqualTo(poll);
+    }
+
+    @Test
+    @DisplayName("getPollById 실행에서 PollId가 존재하지 않는 경우 예외가 발생한다")
+    void getPollById_returnsNull_whenPollDoesNotExist() {
+        // given
+        when(pollRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        ResponseStatusException exception = assertThrows(
+                ResponseStatusException.class,
+                () -> pollService.getPollById(1L)
+        );
+
+        assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(exception.getReason()).isEqualTo(POLL_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("schedulePoll을 통해 state 변경에 성공한다")
+    void schedulePoll_changesStateToScheduled() {
+        // given
+        when(pollRepository.save(Mockito.any(Poll.class))).thenReturn(poll);
+
+        // when
+        pollService.schedulePoll(poll);
+
+        // then
+        assertThat(poll.getState()).isEqualTo(PollState.SCHEDULED);
+        Mockito.verify(pollRepository, Mockito.times(1)).save(poll);
+    }
+
+    @Test
+    @DisplayName("publishPoll을 통해 state 변경에 성공한다")
+    void publishPoll_changesStateToPublished() {
+        // given
+        when(pollRepository.existsByState(PollState.PUBLISHED)).thenReturn(false);
+        when(pollRepository.save(Mockito.any(Poll.class))).thenReturn(poll);
+
+        // when
+        pollService.publishPoll(poll);
+
+        // then
+        assertThat(poll.getState()).isEqualTo(PollState.PUBLISHED);
+        Mockito.verify(pollRepository, Mockito.times(1)).save(poll);
+    }
+
+    @Test
+    @DisplayName("publishPoll에서 이미 PUBLISHED 상태인 투표가 있을 경우 예외를 반환한다")
+    void publishPoll_throwsException_whenPollAlreadyPublished() {
+        // given
+        when(pollRepository.existsByState(PollState.PUBLISHED)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> pollService.publishPoll(poll))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining(PUBLISHED_POLL_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("deletePoll을 통해 state 변경에 성공한다")
+    void deletePoll_changesStateToDeleted() {
+        // given
+        when(pollRepository.save(Mockito.any(Poll.class))).thenReturn(poll);
+
+        // when
+        pollService.deletePoll(poll);
+
+        // then
+        assertThat(poll.getState()).isEqualTo(PollState.DELETED);
+        Mockito.verify(pollRepository, Mockito.times(1)).save(poll);
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/service/VoteServiceTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/service/VoteServiceTest.java
@@ -1,6 +1,5 @@
 package com.tamnara.backend.poll.service;
 
-import com.tamnara.backend.global.util.CreateUserUtil;
 import com.tamnara.backend.poll.domain.*;
 import com.tamnara.backend.poll.exception.*;
 import com.tamnara.backend.poll.repository.PollOptionRepository;
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;

--- a/backend/src/test/java/com/tamnara/backend/poll/service/VoteServiceTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/service/VoteServiceTest.java
@@ -1,0 +1,167 @@
+package com.tamnara.backend.poll.service;
+
+import com.tamnara.backend.global.util.CreateUserUtil;
+import com.tamnara.backend.poll.domain.*;
+import com.tamnara.backend.poll.exception.*;
+import com.tamnara.backend.poll.repository.PollOptionRepository;
+import com.tamnara.backend.poll.repository.PollRepository;
+import com.tamnara.backend.poll.repository.VoteRepository;
+import com.tamnara.backend.poll.util.PollTestBuilder;
+import com.tamnara.backend.user.domain.User;
+import com.tamnara.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VoteServiceTest {
+
+    @Mock private PollRepository pollRepository;
+    @Mock private PollOptionRepository pollOptionRepository;
+    @Mock private VoteRepository voteRepository;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks private VoteService voteService;
+
+    private User user;
+    private Poll poll;
+    private PollOption option1;
+    private PollOption option2;
+    private PollOption option3;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .username("testuser")
+                .build();
+
+        poll = Poll.builder()
+                .id(1L)
+                .minChoices(1)
+                .maxChoices(2)
+                .startAt(LocalDateTime.now().minusHours(1))
+                .endAt(LocalDateTime.now().plusHours(1))
+                .state(PollState.PUBLISHED)
+                .build();
+
+        option1 = PollOption.builder()
+                .id(101L)
+                .title("Option 1")
+                .poll(poll)
+                .build();
+
+        option2 = PollOption.builder()
+                .id(102L)
+                .title("Option 2")
+                .poll(poll)
+                .build();
+
+        option3 = PollOption.builder()
+                .id(103L)
+                .title("Option 3")
+                .poll(poll)
+                .build();
+    }
+
+    @Test
+    @DisplayName("투표 기록 저장에 성공한다")
+    void vote_success() {
+        // given
+        when(pollRepository.findById(1L)).thenReturn(Optional.of(poll));
+        when(pollOptionRepository.findAllById(List.of(101L, 102L))).thenReturn(List.of(option1, option2));
+        when(voteRepository.findByUserIdAndPollId(user.getId(), poll.getId())).thenReturn(Collections.emptyList());
+
+        // when
+        voteService.vote(poll.getId(), user, List.of(101L, 102L));
+
+        // then
+        verify(voteRepository, times(1)).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("투표 대상 투표가 존재하지 않는 경우 404 예외를 반환한다")
+    void vote_pollNotFound() {
+        // given
+        when(pollRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> voteService.vote(1L, user, List.of(101L)))
+                .isInstanceOf(PollNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("투표가 PUBLISHED 상태가 아닌 경우 403 예외를 반환한다")
+    void vote_pollNotPublished() {
+        // given
+        poll.changeState(PollState.SCHEDULED);
+        when(pollRepository.findById(1L)).thenReturn(Optional.of(poll));
+
+        // when & then
+        assertThatThrownBy(() -> voteService.vote(1L, user, List.of(101L)))
+                .isInstanceOf(PollForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("투표 기간이 아닌 경우 403 예외를 반환한다")
+    void vote_outOfPeriod() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        poll = PollTestBuilder.build("test", 1, 2, now.plusDays(1), now.plusDays(3), PollState.PUBLISHED);
+        when(pollRepository.findById(1L)).thenReturn(Optional.of(poll));
+
+        // then
+        assertThatThrownBy(() -> voteService.vote(1L, user, List.of(101L)))
+                .isInstanceOf(PollForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("옵션 ID가 잘못된 경우 404 예외를 반환한다")
+    void vote_optionNotFound() {
+        // given
+        when(pollRepository.findById(1L)).thenReturn(Optional.of(poll));
+        when(pollOptionRepository.findAllById(List.of(101L))).thenReturn(Collections.emptyList());
+
+        // when & then
+        assertThatThrownBy(() -> voteService.vote(1L, user, List.of(101L)))
+                .isInstanceOf(PollNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("이미 투표한 경우 409 예외를 반환한다")
+    void vote_alreadyVoted() {
+        // given
+        when(pollRepository.findById(1L)).thenReturn(Optional.of(poll));
+        when(pollOptionRepository.findAllById(List.of(101L))).thenReturn(List.of(option1));
+        when(voteRepository.findByUserIdAndPollId(user.getId(), poll.getId())).thenReturn(List.of(mock(Vote.class)));
+
+        // when & then
+        assertThatThrownBy(() -> voteService.vote(1L, user, List.of(101L)))
+                .isInstanceOf(PollConflictException.class);
+    }
+
+    @Test
+    @DisplayName("선택된 옵션 수가 범위를 벗어나는 경우 400 예외를 반환한다")
+    void vote_optionCountInvalid() {
+        // given
+        when(pollRepository.findById(1L)).thenReturn(Optional.of(poll));
+        when(pollOptionRepository.findAllById(List.of(101L, 102L, 103L)))
+                .thenReturn(List.of(option1, option2, option3));
+
+        // when & then
+        assertThatThrownBy(() -> voteService.vote(1L, user, List.of(101L, 102L, 103L)))
+                .isInstanceOf(PollBadRequestException.class);
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/service/VoteStatisticsServiceTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/service/VoteStatisticsServiceTest.java
@@ -1,0 +1,98 @@
+package com.tamnara.backend.poll.service;
+
+import com.tamnara.backend.poll.domain.*;
+import com.tamnara.backend.poll.dto.PollStatisticsResponse;
+import com.tamnara.backend.poll.exception.PollNotFoundException;
+import com.tamnara.backend.poll.repository.PollRepository;
+import com.tamnara.backend.poll.repository.VoteRepository;
+import com.tamnara.backend.poll.repository.VoteStatisticsRepository;
+import com.tamnara.backend.poll.util.PollOptionTestBuilder;
+import com.tamnara.backend.poll.util.PollTestBuilder;
+import com.tamnara.backend.poll.util.VoteStatisticsBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.tamnara.backend.poll.constant.PollResponseMessage.POLL_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VoteStatisticsServiceTest {
+
+    @Mock
+    private PollRepository pollRepository;
+
+    @Mock
+    private VoteRepository voteRepository;
+
+    @Mock
+    private VoteStatisticsRepository voteStatisticsRepository;
+
+    @InjectMocks
+    private VoteStatisticsService voteStatisticsService;
+
+    private Poll poll;
+    private PollOption option;
+    private VoteStatistics statistics;
+
+    @BeforeEach
+    void setUp() {
+        poll = PollTestBuilder.defaultPoll();
+        option = PollOptionTestBuilder.defaultOption(poll);
+        poll.getOptions().add(option);
+        statistics = VoteStatisticsBuilder.buildNew(poll, option, 5L);
+    }
+
+    @Test
+    @DisplayName("generateAllStatistics 실행 시 통계가 업데이트 된다")
+    void generateAllStatistics_updatesStatisticsCorrectly() {
+        // given
+        when(pollRepository.findByState(PollState.PUBLISHED)).thenReturn(List.of(poll));
+        when(voteRepository.countByPollIdAndOptionId(poll.getId(), option.getId())).thenReturn(5L);
+        when(voteStatisticsRepository.findByPollIdAndOptionId(poll.getId(), option.getId())).thenReturn(Optional.empty());
+
+        // when
+        voteStatisticsService.generateAllStatistics();
+
+        // then
+        verify(voteStatisticsRepository).save(any(VoteStatistics.class));
+    }
+
+    @Test
+    @DisplayName("getPollStatistics는 올바른 통계 정보를 반환한다")
+    void getPollStatistics_returnsCorrectResponse() {
+        // given
+        when(pollRepository.findById(poll.getId())).thenReturn(Optional.of(poll));
+        when(voteStatisticsRepository.findByPollIdAndOptionId(poll.getId(), option.getId())).thenReturn(Optional.of(statistics));
+
+        // when
+        PollStatisticsResponse response = voteStatisticsService.getPollStatistics(poll.getId());
+
+        // then
+        assertThat(response.getPollId()).isEqualTo(poll.getId());
+        assertThat(response.getResults()).hasSize(1);
+        assertThat(response.getResults().get(0).getCount()).isEqualTo(5);
+        assertThat(response.getTotalVotes()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("getPollStatistics는 Poll이 존재하지 않을 경우 예외를 발생시킨다")
+    void getPollStatistics_throwsException_whenPollNotFound() {
+        // given
+        when(pollRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> voteStatisticsService.getPollStatistics(1L))
+                .isInstanceOf(PollNotFoundException.class)
+                .hasMessage(POLL_NOT_FOUND);
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/util/PollCreateRequestTestBuilder.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/util/PollCreateRequestTestBuilder.java
@@ -1,0 +1,27 @@
+package com.tamnara.backend.poll.util;
+
+import com.tamnara.backend.poll.dto.PollCreateRequest;
+import com.tamnara.backend.poll.dto.PollOptionCreateRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PollCreateRequestTestBuilder {
+    public static PollCreateRequest build(
+            String title,
+            int minChoices,
+            int maxChoices,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            List<PollOptionCreateRequest> options
+    ) {
+        return PollCreateRequest.builder()
+                .title(title)
+                .minChoices(minChoices)
+                .maxChoices(maxChoices)
+                .startAt(startAt)
+                .endAt(endAt)
+                .options(options)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/util/PollTestBuilder.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/util/PollTestBuilder.java
@@ -4,6 +4,7 @@ import com.tamnara.backend.poll.domain.Poll;
 import com.tamnara.backend.poll.domain.PollState;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 
 public class PollTestBuilder {
 
@@ -22,6 +23,7 @@ public class PollTestBuilder {
                 .startAt(startAt)
                 .endAt(endAt)
                 .state(state)
+                .options(new ArrayList<>())
                 .build();
     }
 


### PR DESCRIPTION
## feat:  단위 테스트 for PollService, VoteService, and VoteStatisticsService

### 관련 이슈
#284 

### 주요 변경사항

- **PollServiceTest**
  - `createPoll` 정상 플로우 및 예외 처리(`minChoices` > `maxChoices`, `startAt` > `endAt`)
  - `getPollById` 정상 및 Poll 미존재 시 예외 처리
  - `schedulePoll`, `publishPoll`, `deletePoll`에 대한 상태 변경 테스트
  - 이미 `PUBLISHED` 투표 존재 시 예외 반환 테스트

- **VoteServiceTest**
  - 정상 투표 시나리오
  - 잘못된 투표 옵션/선택 수/중복 투표 등 다양한 예외 시나리오 테스트

- **VoteStatisticsServiceTest**
  - `generateAllStatistics` 실행 시 통계 생성/업데이트 검증
  - `getPollStatistics` 정상 응답 및 Poll 미존재 시 예외 발생 검증

### 참고
각 테스트에서 Mockito를 활용한 repository/service mocking을 적용해 실제 비즈니스 로직이 정상 동작하는지 검증함.
