### PR TITLE
feat: Scheduler 관련 유닛 테스트 추가

### DIFF
--- a/backend/src/test/java/com/tamnara/backend/poll/scheduler/PollStateSchedulerTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/scheduler/PollStateSchedulerTest.java
@@ -1,0 +1,112 @@
+package com.tamnara.backend.poll.scheduler;
+
+import com.tamnara.backend.poll.domain.Poll;
+import com.tamnara.backend.poll.domain.PollState;
+import com.tamnara.backend.poll.repository.PollRepository;
+import com.tamnara.backend.poll.service.PollService;
+import com.tamnara.backend.poll.util.PollTestBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PollStateSchedulerTest {
+
+    @Mock
+    private PollRepository pollRepository;
+
+    @Mock
+    private PollService pollService;
+
+    @InjectMocks
+    private PollStateScheduler pollStateScheduler;
+
+    private Poll pollToDelete;
+    private Poll pollToPublish;
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime now = LocalDateTime.now();
+
+        pollToDelete = Poll.builder()
+                .id(1L)
+                .minChoices(1)
+                .maxChoices(2)
+                .startAt(LocalDateTime.now().minusMinutes(10))
+                .endAt(LocalDateTime.now().minusMinutes(1)) // 종료된 투표
+                .state(PollState.PUBLISHED)
+                .build();
+
+        pollToPublish = Poll.builder()
+                .id(1L)
+                .minChoices(1)
+                .maxChoices(2)
+                .startAt(LocalDateTime.now().minusMinutes(1)) // 시작된 투표
+                .endAt(LocalDateTime.now().plusMinutes(10)) // 아직 유효함
+                .state(PollState.SCHEDULED)
+                .build();
+    }
+
+    @Test
+    @DisplayName("종료된 PUBLISHED 투표는 DELETED 상태로 변경된다")
+    void updatePollStates_deletesExpiredPolls() {
+        // given
+        when(pollRepository.findByStateAndEndAtBefore(eq(PollState.PUBLISHED), any()))
+                .thenReturn(List.of(pollToDelete));
+
+        when(pollRepository.findByStateAndStartAtBeforeAndEndAtAfter(eq(PollState.SCHEDULED), any(), any()))
+                .thenReturn(List.of());
+
+        // when
+        pollStateScheduler.updatePollStates();
+
+        // then
+        verify(pollService).deletePoll(pollToDelete);
+        verify(pollService, never()).publishPoll(any());
+    }
+
+    @Test
+    @DisplayName("시작 시간이 지난 SCHEDULED 투표 중 가장 빠른 투표를 PUBLISHED 상태로 변경한다")
+    void updatePollStates_publishesScheduledPoll() {
+        // given
+        when(pollRepository.findByStateAndEndAtBefore(eq(PollState.PUBLISHED), any()))
+                .thenReturn(List.of());
+
+        when(pollRepository.findByStateAndStartAtBeforeAndEndAtAfter(eq(PollState.SCHEDULED), any(), any()))
+                .thenReturn(List.of(pollToPublish));
+
+        // when
+        pollStateScheduler.updatePollStates();
+
+        // then
+        verify(pollService).publishPoll(pollToPublish);
+        verify(pollService, never()).deletePoll(any());
+    }
+
+    @Test
+    @DisplayName("변경할 투표가 없으면 아무 동작도 하지 않는다")
+    void updatePollStates_noChanges() {
+        // given
+        when(pollRepository.findByStateAndEndAtBefore(eq(PollState.PUBLISHED), any()))
+                .thenReturn(List.of());
+
+        when(pollRepository.findByStateAndStartAtBeforeAndEndAtAfter(eq(PollState.SCHEDULED), any(), any()))
+                .thenReturn(List.of());
+
+        // when
+        pollStateScheduler.updatePollStates();
+
+        // then
+        verify(pollService, never()).deletePoll(any());
+        verify(pollService, never()).publishPoll(any());
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/poll/scheduler/VoteStatisticsSchedulerTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/scheduler/VoteStatisticsSchedulerTest.java
@@ -1,0 +1,32 @@
+package com.tamnara.backend.poll.scheduler;
+
+import com.tamnara.backend.poll.service.VoteStatisticsService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class VoteStatisticsSchedulerTest {
+
+    @Mock
+    private VoteStatisticsService voteStatisticsService;
+
+    @InjectMocks
+    private VoteStatisticsScheduler voteStatisticsScheduler;
+
+    @Test
+    @DisplayName("generateVoteStatistics는 voteStatisticsService.generateAllStatistics()를 호출한다")
+    void generateVoteStatistics_callsServiceMethod() {
+        // when
+        voteStatisticsScheduler.generateVoteStatistics();
+
+        // then
+        verify(voteStatisticsService, times(1)).generateAllStatistics();
+    }
+}


### PR DESCRIPTION
## 스케줄러 유닛 테스트 추가

### 관련 이슈
#296 

### 주요 변경 사항
`PollStateScheduler`와 `VoteStatisticsScheduler`에 대한 유닛 테스트를 추가하였습니다.

### 변경 내역
- `PollStateSchedulerTest` 작성
  - 종료 시간이 지난 PUBLISHED 투표가 DELETED 상태로 전환되는지 검증
  - 시작 시간이 현재보다 이전인 SCHEDULED 투표 중 가장 이른 투표가 PUBLISHED 상태로 전환되는지 검증
- `VoteStatisticsSchedulerTest` 작성
  - 스케줄러가 `VoteStatisticsService.generateAllStatistics()`를 정확히 한 번 호출하는지 검증

### 테스트 범위
- `@Scheduled` 어노테이션은 실제 테스트에서 실행되지 않기 때문에 해당 메서드를 직접 호출하여 로직을 검증하였습니다.
- 로그 출력은 검증하지 않고, 서비스 메서드 호출 여부에 중점을 두었습니다.

### 참고 사항
- 실제 스케줄링 동작 여부는 통합 테스트나 운영 환경에서 확인해야 합니다.
- 서비스 레이어에 대한 의존성을 Mocking하여 단위 테스트 수준에서 빠르게 검증할 수 있도록 구성했습니다.