### PR TITLE
fix: QueryDSL 의존성 포함 리포지토리 테스트에 QuerydslConfig 설정 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/BackendApplication.java
+++ b/backend/src/main/java/com/tamnara/backend/BackendApplication.java
@@ -2,10 +2,8 @@ package com.tamnara.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
-@EnableAsync
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/tamnara/backend/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.tamnara.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/backend/src/test/java/com/tamnara/backend/news/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/CategoryRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.tamnara.backend.news.repository;
 
 import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
 import com.tamnara.backend.news.domain.Category;
 import com.tamnara.backend.news.domain.CategoryType;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import(JpaConfig.class)
+@Import({JpaConfig.class, QuerydslConfig.class})
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class CategoryRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsImageRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsImageRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.tamnara.backend.news.repository;
 
 import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsImage;
 import jakarta.persistence.EntityManager;
@@ -20,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@Import(JpaConfig.class)
+@Import({JpaConfig.class, QuerydslConfig.class})
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class NewsImageRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.tamnara.backend.news.repository;
 
 import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsTag;
 import com.tamnara.backend.news.domain.Tag;
@@ -23,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@Import(JpaConfig.class)
+@Import({JpaConfig.class, QuerydslConfig.class})
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class NewsTagRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/TagRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/TagRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.tamnara.backend.news.repository;
 
 import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsTag;
 import com.tamnara.backend.news.domain.Tag;
@@ -23,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import(JpaConfig.class)
+@Import({JpaConfig.class, QuerydslConfig.class})
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class TagRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/TimelineCardRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/TimelineCardRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.tamnara.backend.news.repository;
 
 import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.TimelineCard;
 import com.tamnara.backend.news.domain.TimelineCardType;
@@ -25,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import(JpaConfig.class)
+@Import({JpaConfig.class, QuerydslConfig.class})
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class TimelineCardRepositoryTest {


### PR DESCRIPTION
## 연관된 이슈
#301 

<br/>

## 작업 내용
- [x] `@EnableAsync` 어노테이션을 설정 클래스로 책임 분리하는 커밋을 cherry-pick
- [x] QueryDSL 의존성 포함 리포지토리 테스트에 QuerydslConfig 설정 추가

<br/>

## 상세 내용
### QueryDSL 의존성 포함 리포지토리 테스트에 QuerydslConfig 설정 추가
- **작업한 파일:**
   - 카테고리 리포지토리
   - 뉴스 이미지 리포지토리
   - 뉴스태그 리포지토리
   - 태그 리포지토리
   - 타임라인 카드 리포지토리
```java
@Import({JpaConfig.class, QuerydslConfig.class})
public class RepositoryTest
```