### PR TITLE
feat: JpaConfig와 QuerydslConfig를 추가한 테스트용 설정 클래스 추가

### DIFF
--- a/backend/src/test/java/com/tamnara/backend/config/TestConfig.java
+++ b/backend/src/test/java/com/tamnara/backend/config/TestConfig.java
@@ -1,0 +1,11 @@
+package com.tamnara.backend.config;
+
+import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@TestConfiguration
+@Import({JpaConfig.class, QuerydslConfig.class})
+public class TestConfig {
+}


### PR DESCRIPTION
## 연관된 이슈
#301 

<br/>

## 작업 내용
- [x] `JpaConfig`와 `QuerydslConfig`를 추가한 테스트용 설정 클래스 추가

<br/>

## 상세 내용
### 테스트용 설정 클래스 추가
```java
@TestConfiguration
@Import({JpaConfig.class, QuerydslConfig.class})
public class TestConfig {
}
```