### PR TITLE
refactor: 리포지토리 테스트의 @import 목록을 TestConfig로 변경

### DIFF
--- a/backend/src/test/java/com/tamnara/backend/alarm/repository/AlarmRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/repository/AlarmRepositoryTest.java
@@ -3,8 +3,7 @@ package com.tamnara.backend.alarm.repository;
 import com.tamnara.backend.alarm.domain.Alarm;
 import com.tamnara.backend.alarm.domain.AlarmType;
 import com.tamnara.backend.alarm.domain.UserAlarm;
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.user.domain.Role;
 import com.tamnara.backend.user.domain.State;
 import com.tamnara.backend.user.domain.User;
@@ -32,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class AlarmRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/alarm/repository/UserAlarmRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/repository/UserAlarmRepositoryTest.java
@@ -5,8 +5,7 @@ import com.tamnara.backend.alarm.domain.AlarmType;
 import com.tamnara.backend.alarm.domain.UserAlarm;
 import com.tamnara.backend.bookmark.domain.Bookmark;
 import com.tamnara.backend.bookmark.repository.BookmarkRepository;
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.repository.NewsRepository;
 import com.tamnara.backend.user.domain.Role;
@@ -40,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class UserAlarmRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/alarm/repository/UserAlarmRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/alarm/repository/UserAlarmRepositoryTest.java
@@ -61,6 +61,7 @@ public class UserAlarmRepositoryTest {
         userRepository.deleteAll();
         alarmRepository.deleteAll();
         userAlarmRepository.deleteAll();
+        em.clear();
 
         user = User.builder()
                 .email("이메일")

--- a/backend/src/test/java/com/tamnara/backend/bookmark/repository/BookmarkRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/bookmark/repository/BookmarkRepositoryTest.java
@@ -2,7 +2,7 @@ package com.tamnara.backend.bookmark.repository;
 
 import com.tamnara.backend.bookmark.constant.BookmarkServiceConstant;
 import com.tamnara.backend.bookmark.domain.Bookmark;
-import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.repository.NewsRepository;
 import com.tamnara.backend.user.domain.Role;
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@Import(JpaConfig.class)
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class BookmarkRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/comment/repository/CommentRepositoryTest.java
@@ -2,7 +2,7 @@ package com.tamnara.backend.comment.repository;
 
 import com.tamnara.backend.comment.constant.CommentServiceConstant;
 import com.tamnara.backend.comment.domain.Comment;
-import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.repository.NewsRepository;
 import com.tamnara.backend.user.domain.Role;
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@Import(JpaConfig.class)
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class CommentRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/CategoryRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.Category;
 import com.tamnara.backend.news.domain.CategoryType;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class CategoryRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsImageRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsImageRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsImage;
 import jakarta.persistence.EntityManager;
@@ -21,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class NewsImageRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.constant.NewsServiceConstant;
 import com.tamnara.backend.news.domain.Category;
 import com.tamnara.backend.news.domain.CategoryType;
@@ -42,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class NewsRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsTag;
 import com.tamnara.backend.news.domain.Tag;
@@ -24,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class NewsTagRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/TagRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/TagRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsTag;
 import com.tamnara.backend.news.domain.Tag;
@@ -24,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class TagRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/TimelineCardRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/TimelineCardRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.TimelineCard;
 import com.tamnara.backend.news.domain.TimelineCardType;
@@ -26,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class TimelineCardRepositoryTest {


### PR DESCRIPTION
## 연관된 이슈
#301 

<br/>

## 작업 내용
- [x] 뉴스 기능의 리포지토리 테스트의 `@Import` 목록을 TestConfig로 변경
- [x] 댓글 기능의 리포지토리 테스트의 `@Import` 목록을 TestConfig로 변경
- [x] 북마크 기능의 리포지토리 테스트의 `@Import` 목록을 TestConfig로 변경
- [x] 알림 기능의 리포지토리 테스트의 `@Import` 목록을 TestConfig로 변경
- [x] 회원알림 리포지토리 테스트의 `@BeforeEach`에서 deleteAll 후 `em.clear` 추가

<br/>

## 상세 내용
### 리포지토리 테스트의 `@Import` 목록을 TestConfig로 변경
```java
@DataJpaTest
@Import(TestConfig.class)
@ActiveProfiles("test")
@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
public class XXXRepositoryTest
```