### PR TITLE
feat: 알림 처리를 위한 뉴스 리포지토리 메서드 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/news/repository/NewsRepository.java
@@ -45,6 +45,12 @@ public interface NewsRepository extends JpaRepository<News, Long>, NewsSearchRep
     """, nativeQuery = true)
     Optional<News> findNewsByExactlyMatchingTags(@Param("keywords") List<String> keywords, @Param("size") Integer size);
 
+    @Query("""
+        SELECT n FROM News n
+        WHERE n.updatedAt < :cutoff
+    """)
+    List<News> findAllOlderThan(@Param("cutoff") LocalDateTime cutoff);
+
     @Modifying
     @Query("UPDATE News n SET n.isHotissue = :isHotissue WHERE n.id = :newsId")
     void updateIsHotissue(@Param("newsId") Long newsId, @Param("isHotissue") boolean isHotissue);

--- a/backend/src/test/java/com/tamnara/backend/config/TestConfig.java
+++ b/backend/src/test/java/com/tamnara/backend/config/TestConfig.java
@@ -1,0 +1,11 @@
+package com.tamnara.backend.config;
+
+import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@TestConfiguration
+@Import({JpaConfig.class, QuerydslConfig.class})
+public class TestConfig {
+}

--- a/backend/src/test/java/com/tamnara/backend/news/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/CategoryRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.Category;
 import com.tamnara.backend.news.domain.CategoryType;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class CategoryRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsImageRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsImageRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsImage;
 import jakarta.persistence.EntityManager;
@@ -21,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class NewsImageRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
@@ -336,7 +336,7 @@ public class NewsRepositoryTest {
     }
 
     @Test
-    void 수정일자가_기준시간보다_오래된_뉴스_일괄_삭제_검증() {
+    void 수정시간이_기준시간보다_오래된_뉴스_일괄_조회_검증() {
         // given
         News news1 = createNews("제목", "미리보기 내용", user, category);
         news1.setIsHotissue(true);
@@ -346,6 +346,38 @@ public class NewsRepositoryTest {
         news2.setIsHotissue(true);
         newsRepository.saveAndFlush(news2);
 
+        LocalDateTime cutoff;
+        try {
+            Thread.sleep(1000); // 1초
+            cutoff = LocalDateTime.now();
+            Thread.sleep(1000); // 1초
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        News news3 = createNews("제목", "미리보기 내용", user, category);
+        news3.setIsHotissue(true);
+        newsRepository.saveAndFlush(news3);
+
+        // when
+        List<News> newsList = newsRepository.findAllOlderThan(cutoff);
+
+        // then
+        assertEquals(2, newsList.size());
+        assertEquals(news1.getId(), newsList.get(0).getId());
+        assertEquals(news2.getId(), newsList.get(1).getId());
+    }
+
+    @Test
+    void 수정시간이_기준시간보다_오래된_뉴스_일괄_삭제_검증() {
+        // given
+        News news1 = createNews("제목", "미리보기 내용", user, category);
+        news1.setIsHotissue(true);
+        newsRepository.saveAndFlush(news1);
+
+        News news2 = createNews("제목", "미리보기 내용", user, category);
+        news2.setIsHotissue(true);
+        newsRepository.saveAndFlush(news2);
 
         LocalDateTime cutoff;
         try {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.constant.NewsServiceConstant;
 import com.tamnara.backend.news.domain.Category;
 import com.tamnara.backend.news.domain.CategoryType;
@@ -42,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class NewsRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/NewsTagRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsTag;
 import com.tamnara.backend.news.domain.Tag;
@@ -24,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class NewsTagRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/TagRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/TagRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.NewsTag;
 import com.tamnara.backend.news.domain.Tag;
@@ -24,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class TagRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/news/repository/TimelineCardRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/repository/TimelineCardRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.tamnara.backend.news.repository;
 
-import com.tamnara.backend.global.config.JpaConfig;
-import com.tamnara.backend.global.config.QuerydslConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.domain.TimelineCard;
 import com.tamnara.backend.news.domain.TimelineCardType;
@@ -26,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
-@Import({JpaConfig.class, QuerydslConfig.class})
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class TimelineCardRepositoryTest {


### PR DESCRIPTION
## 연관된 이슈
#288 

<br/>

## 작업 내용
- [x] 알림 처리를 위한 뉴스 리포지토리 메서드 추가

<br/>

## 상세 내용
### 알림 처리를 위한 뉴스 리포지토리 메서드 추가
- **작업한 파일:** `news.repository.NewsRepository`
```java
@Query("""
        SELECT n FROM News n
        WHERE n.updatedAt < :cutoff
    """)
    List<News> findAllOlderThan(@Param("cutoff") LocalDateTime cutoff);
```
- **테스트 추가**
   - 수정시간이 기준시간보다 오래된 뉴스 일괄 조회 검증 추가