### PR TITLE
feat: 댓글 목록 조회 응답에 회원 이름 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ repositories {
 ext {
 	set('springCloudVersion', "2024.0.1")
 	set('tanzuScgExtensionsVersion', "1.0.0")
+	set('querydslVersion', "5.0.0")
 }
 
 dependencies {
@@ -39,6 +40,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// QueryDSL
+	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -62,12 +69,20 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
+	// AI 연동
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310' // LocalDate를 JSON으로 직렬화
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.batch:spring-batch-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.mockito:mockito-core:5.18.0'
 	testImplementation 'org.mockito:mockito-junit-jupiter:5.18.0'
+
+	// Actuator & Micrometer + Prometheus
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 }
 
 tasks.named('test') {
@@ -77,4 +92,15 @@ tasks.named('test') {
 checkstyle {
 	toolVersion = '10.3.4' // 버전 수정 가능
 	configFile = file("${rootDir}/config/checkstyle/checkstyle.xml") // ✅ 규칙 파일 경로
+}
+
+// QueryDSL 설정
+def querydslDir = file("build/generated/sources/annotationProcessor/java/main")
+
+sourceSets {
+	main {
+		java {
+			srcDirs += querydslDir
+		}
+	}
 }

--- a/backend/src/main/java/com/tamnara/backend/comment/dto/CommentDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/dto/CommentDTO.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 public class CommentDTO {
     private Long id;
     private Long userId;
+    private String username;
 
     @Length(min = 1, message = "댓글란은 비어 있을 수 없습니다.")
     @Length(max = 150, message = "댓글 최대 길이를 초과하였습니다.")

--- a/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
@@ -47,6 +47,7 @@ public class CommentServiceImpl implements CommentService {
             CommentDTO dto = new CommentDTO(
                     c.getId(),
                     c.getUser().getId(),
+                    c.getUser().getUsername(),
                     c.getContent(),
                     c.getCreatedAt()
             );

--- a/backend/src/main/java/com/tamnara/backend/global/config/QuerydslConfig.java
+++ b/backend/src/main/java/com/tamnara/backend/global/config/QuerydslConfig.java
@@ -1,0 +1,14 @@
+package com.tamnara.backend.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/tamnara/backend/comment/controller/CommentControllerTest.java
@@ -45,13 +45,13 @@ public class CommentControllerTest {
     @Autowired private ObjectMapper objectMapper;
     @Autowired private CommentService commentService;
 
-    private static final Long USER_ID = 1L;
+    User user;
     private static final Long NEWS_ID = 1L;
 
     @BeforeEach
     void setupSecurityContext() {
-        User user = User.builder()
-                .id(USER_ID)
+        user = User.builder()
+                .id(1L)
                 .username("테스트유저")
                 .role(Role.USER)
                 .build();
@@ -66,7 +66,8 @@ public class CommentControllerTest {
     private CommentDTO createCommentDTO(Long id, LocalDateTime createdAt) {
         return new CommentDTO(
                 id,
-                USER_ID,
+                user.getId(),
+                user.getUsername(),
                 "댓글 내용",
                 createdAt
         );

--- a/backend/src/test/java/com/tamnara/backend/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/comment/repository/CommentRepositoryTest.java
@@ -2,7 +2,7 @@ package com.tamnara.backend.comment.repository;
 
 import com.tamnara.backend.comment.constant.CommentServiceConstant;
 import com.tamnara.backend.comment.domain.Comment;
-import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.config.TestConfig;
 import com.tamnara.backend.news.domain.News;
 import com.tamnara.backend.news.repository.NewsRepository;
 import com.tamnara.backend.user.domain.Role;
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
-@Import(JpaConfig.class)
+@Import(TestConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class CommentRepositoryTest {

--- a/backend/src/test/java/com/tamnara/backend/comment/service/CommentServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/comment/service/CommentServiceImplTest.java
@@ -45,16 +45,13 @@ public class CommentServiceImplTest {
     private User user;
     private News news;
 
-    private static final Long USER_ID = 1L;
-    private static final Long NEWS_ID = 1L;
-
     @BeforeEach
     void setUp() {
         user = mock(User.class);
-        lenient().when(user.getId()).thenReturn(USER_ID);
+        lenient().when(user.getId()).thenReturn(1L);
 
         news = mock(News.class);
-        lenient().when(news.getId()).thenReturn(NEWS_ID);
+        lenient().when(news.getId()).thenReturn(1L);
     }
 
     private Comment createComment(User user, News news) {
@@ -74,11 +71,11 @@ public class CommentServiceImplTest {
         Page<Comment> commentPage = new PageImpl<>(Arrays.asList(comment1, comment2, comment3));
 
         when(newsRepository.existsById(1L)).thenReturn(true);
-        when(commentRepository.findAllByNewsIdOrderByIdAsc(NEWS_ID, PageRequest.of(0, CommentServiceConstant.PAGE_SIZE))).thenReturn(commentPage);
-        when(commentRepository.findAllByNewsIdOrderByIdAsc(NEWS_ID, PageRequest.of(1, CommentServiceConstant.PAGE_SIZE))).thenReturn(Page.empty());
+        when(commentRepository.findAllByNewsIdOrderByIdAsc(news.getId(), PageRequest.of(0, CommentServiceConstant.PAGE_SIZE))).thenReturn(commentPage);
+        when(commentRepository.findAllByNewsIdOrderByIdAsc(news.getId(), PageRequest.of(1, CommentServiceConstant.PAGE_SIZE))).thenReturn(Page.empty());
 
         // when
-        CommentListResponse response = commentServiceImpl.getComments(NEWS_ID, 0);
+        CommentListResponse response = commentServiceImpl.getComments(news.getId(), 0);
 
         // then
         assertEquals(3, response.getComments().size());
@@ -93,8 +90,8 @@ public class CommentServiceImplTest {
         Comment comment = createComment(user, news);
         CommentCreateRequest request = new CommentCreateRequest(comment.getContent());
 
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(newsRepository.findById(NEWS_ID)).thenReturn(Optional.of(news));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(newsRepository.findById(news.getId())).thenReturn(Optional.of(news));
         when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
             Comment savedComment = invocation.getArgument(0);
             savedComment.setId(commentId);
@@ -102,7 +99,7 @@ public class CommentServiceImplTest {
         });
 
         // when
-        Long returnedCommentId = commentServiceImpl.save(USER_ID, NEWS_ID, request);
+        Long returnedCommentId = commentServiceImpl.save(user.getId(), news.getId(), request);
 
         // then
         assertEquals(commentId, returnedCommentId);
@@ -114,12 +111,12 @@ public class CommentServiceImplTest {
         Comment comment = createComment(user, news);
         comment.setId(1L);
 
-        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-        when(newsRepository.findById(NEWS_ID)).thenReturn(Optional.of(news));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(newsRepository.findById(news.getId())).thenReturn(Optional.of(news));
         when(commentRepository.findById(comment.getId())).thenReturn(Optional.of(comment));
 
         // when
-        commentServiceImpl.delete(USER_ID, NEWS_ID, comment.getId());
+        commentServiceImpl.delete(user.getId(), news.getId(), comment.getId());
 
         // then
         assertFalse(commentRepository.existsById(comment.getId()));
@@ -129,12 +126,12 @@ public class CommentServiceImplTest {
     void 내_댓글_아닌_댓글_삭제_불가_검증() {
         // given
         User writer = User.builder()
-                .id(USER_ID)
+                .id(user.getId())
                 .username("작성자")
                 .build();
 
         User anotherUser = User.builder()
-                .id(USER_ID + 1)
+                .id(user.getId() + 1)
                 .username("다른 사용자")
                 .build();
 
@@ -142,12 +139,12 @@ public class CommentServiceImplTest {
         comment.setId(1L);
 
         when(userRepository.findById(anotherUser.getId())).thenReturn(Optional.of(anotherUser));
-        when(newsRepository.findById(NEWS_ID)).thenReturn(Optional.of(news));
+        when(newsRepository.findById(news.getId())).thenReturn(Optional.of(news));
         when(commentRepository.findById(comment.getId())).thenReturn(Optional.of(comment));
 
         // when
         ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
-            commentServiceImpl.delete(anotherUser.getId(), NEWS_ID, comment.getId());
+            commentServiceImpl.delete(anotherUser.getId(), news.getId(), comment.getId());
         });
 
         // then

--- a/backend/src/test/java/com/tamnara/backend/config/TestConfig.java
+++ b/backend/src/test/java/com/tamnara/backend/config/TestConfig.java
@@ -1,0 +1,11 @@
+package com.tamnara.backend.config;
+
+import com.tamnara.backend.global.config.JpaConfig;
+import com.tamnara.backend.global.config.QuerydslConfig;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@TestConfiguration
+@Import({JpaConfig.class, QuerydslConfig.class})
+public class TestConfig {
+}


### PR DESCRIPTION
## 연관된 이슈
#312 

<br/>

## 작업 내용
- [x] 댓글 카드 DTO에 회원 이름 필드 추가
- [x] 댓글 목록 조회 서비스에 회원 이름을 포함하는 로직 추가
- [x] 댓글 서비스 테스트, 컨트롤러 테스트 성공 확인

<br/>

## 상세 내용
### 댓글 카드 DTO에 회원 이름 필드 추가
- **작업한 파일:** `comment.dto.CommentDTO`
- **작업한 내용:** `username` 필드 추가
```java
public class CommentDTO {
    ...
    private String username;
    ...
}
```

### 댓글 목록 조회 서비스에 회원 이름을 포함하는 로직 추가

```java
List<CommentDTO> commentDTOList = new ArrayList<>();
for (Comment c : comments.getContent()) {
    CommentDTO dto = new CommentDTO(
            ...
            c.getUser().getUsername(),
            ...
    );
    commentDTOList.add(dto);
}
```