### PR TITLE
fix: 알림 카드 DTO의 id 필드에 alarm 대신 userAlarm ID 주입

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/alarm/service/AlarmServiceImpl.java
@@ -91,7 +91,7 @@ public class AlarmServiceImpl implements AlarmService {
             Alarm alarm = userAlarm.getAlarm();
 
             AlarmCardDTO dto = new AlarmCardDTO(
-                    alarm.getId(),
+                    userAlarm.getId(),
                     alarm.getTitle(),
                     alarm.getContent(),
                     userAlarm.getIsChecked(),


### PR DESCRIPTION
## 연관된 이슈
#341

<br/>

## 작업 내용
- [x] 알림 카드 DTO의 id 필드에 `alarm` 대신 `userAlarm` ID 주입

<br/>

## 상세 내용
### 댓글 카드 DTO에 회원 이름 필드 추가
- **작업한 파일:** `alarm.service.AlarmServiceImpl`
- **작업한 내용:** 알림 카드 DTO 생성 헬퍼 메서드에서 AlarmCardDTO의 id 필드에 `userAlarm.id` 주입