### PR TITLE
fix: 여론 통계 API 오류로 인한 뉴스 생성/수정 트랜잭션 실패 처리 문제 해결

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -44,6 +44,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -230,8 +231,11 @@ public class NewsServiceImpl implements NewsService {
                 .getAIStatistics(req.getKeywords())
                 .exceptionally(ex -> {
                     Throwable cause = ex instanceof CompletionException ? ex.getCause() : ex;
-                    if (cause instanceof AIException aiEx && aiEx.getStatus() == HttpStatus.NOT_FOUND) {
-                        return null;
+                    if (cause instanceof AIException aiEx) {
+                        HttpStatusCode status = aiEx.getStatus();
+                        if (status.is4xxClientError()) {
+                            return null;
+                        }
                     }
                     throw new CompletionException(cause);
                 });
@@ -326,7 +330,7 @@ public class NewsServiceImpl implements NewsService {
                 news.getUpdatedAt(),
                 true,
                 timeline,
-                statistics
+                statistics != null ? statistics : new StatisticsDTO(0, 0, 0)
         );
     }
 
@@ -385,8 +389,11 @@ public class NewsServiceImpl implements NewsService {
                 .getAIStatistics(keywords)
                 .exceptionally(ex -> {
                     Throwable cause = ex instanceof CompletionException ? ex.getCause() : ex;
-                    if (cause instanceof AIException aiEx && aiEx.getStatus() == HttpStatus.NOT_FOUND) {
-                        return null;
+                    if (cause instanceof AIException aiEx) {
+                        HttpStatusCode status = aiEx.getStatus();
+                        if (status.is4xxClientError()) {
+                            return null;
+                        }
                     }
                     throw new CompletionException(cause);
                 });
@@ -457,7 +464,7 @@ public class NewsServiceImpl implements NewsService {
                 news.getUpdatedAt(),
                 true,
                 newTimeline,
-                statistics
+                statistics != null ? statistics : new StatisticsDTO(0, 0, 0)
         );
     }
 


### PR DESCRIPTION
## 연관된 이슈
#343 

<br/>

## 작업 내용
- [x] 여론 통계 생성 응답이 4xx일 경우 예외 처리 대신 기본값 처리로 변경
- [x] 여론 통계 생성 API가 404를 반환하는 경우 뉴스 생성/업데이트 동작 검증 추가

<br/>

## 상세 내용
### 여론 통계 생성 응답이 4xx일 경우 예외 처리 대신 기본값 처리로 변경
- **작업한 파일:** `news.service.NewsServiceImpl`
- **작업 내용:** 
   - asyncAiService.getAIStatistics() 호출 결과가 4xx일 경우, 응답을 null로 처리한다.
   - 응답 DTO의 여론 통계 필드에 null을 넣는 대신, 기본값 (0, 0, 0)으로 대체한다.
- **테스트 목록:**
   - 여론 통계 생성 API가 404 반환 시 뉴스 생성 성공 검증
   - 여론 통계 생성 API가 404 반환 시 뉴스 업데이트 성공 검증