### PR TITLE
fix: 댓글 목록 조회 리포지토리 메서드명을 최신순 정렬 방식에 맞게 변경

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/repository/CommentRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    Page<Comment> findAllByNewsIdOrderByIdAsc(@Param("id") Long id, Pageable pageable);
+    Page<Comment> findAllByNewsIdOrderByIdDesc(@Param("id") Long id, Pageable pageable);
 }

--- a/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
@@ -39,8 +39,8 @@ public class CommentServiceImpl implements CommentService {
         int page = offset / CommentServiceConstant.PAGE_SIZE;
         int nextOffset = (page + 1) * CommentServiceConstant.PAGE_SIZE;
 
-        Page<Comment> comments = commentRepository.findAllByNewsIdOrderByIdAsc(newsId, PageRequest.of(page, CommentServiceConstant.PAGE_SIZE));
-        boolean hasNext = !commentRepository.findAllByNewsIdOrderByIdAsc(newsId, PageRequest.of(page + 1, CommentServiceConstant.PAGE_SIZE)).isEmpty();
+        Page<Comment> comments = commentRepository.findAllByNewsIdOrderByIdDesc(newsId, PageRequest.of(page, CommentServiceConstant.PAGE_SIZE));
+        boolean hasNext = !commentRepository.findAllByNewsIdOrderByIdDesc(newsId, PageRequest.of(page + 1, CommentServiceConstant.PAGE_SIZE)).isEmpty();
 
         List<CommentDTO> commentDTOList = new ArrayList<>();
         for (Comment c : comments.getContent()) {

--- a/backend/src/test/java/com/tamnara/backend/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/comment/repository/CommentRepositoryTest.java
@@ -187,7 +187,7 @@ public class CommentRepositoryTest {
     }
 
     @Test
-    void 뉴스_ID로_연관된_댓글_전체_조회_시_ID_오름차순_정렬_검증() {
+    void 뉴스_ID로_연관된_댓글_전체_조회_시_ID_내림차순_정렬_검증() {
         // given
         Comment comment1 = createComment("댓글 내용", news, user);
         commentRepository.saveAndFlush(comment1);
@@ -198,14 +198,14 @@ public class CommentRepositoryTest {
 
         // when
         Pageable pageable = PageRequest.of(0, CommentServiceConstant.PAGE_SIZE);
-        Page<Comment> commentPage = commentRepository.findAllByNewsIdOrderByIdAsc(news.getId(), pageable);
+        Page<Comment> commentPage = commentRepository.findAllByNewsIdOrderByIdDesc(news.getId(), pageable);
         List<Comment> commentList = commentPage.getContent();
 
         // then
         assertEquals(3, commentList.size());
-        assertEquals(comment1.getId(), commentList.get(0).getId());
+        assertEquals(comment3.getId(), commentList.get(0).getId());
         assertEquals(comment2.getId(), commentList.get(1).getId());
-        assertEquals(comment3.getId(), commentList.get(2).getId());
+        assertEquals(comment1.getId(), commentList.get(2).getId());
     }
 
     @Test

--- a/backend/src/test/java/com/tamnara/backend/comment/service/CommentServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/comment/service/CommentServiceImplTest.java
@@ -71,8 +71,8 @@ public class CommentServiceImplTest {
         Page<Comment> commentPage = new PageImpl<>(Arrays.asList(comment1, comment2, comment3));
 
         when(newsRepository.existsById(1L)).thenReturn(true);
-        when(commentRepository.findAllByNewsIdOrderByIdAsc(news.getId(), PageRequest.of(0, CommentServiceConstant.PAGE_SIZE))).thenReturn(commentPage);
-        when(commentRepository.findAllByNewsIdOrderByIdAsc(news.getId(), PageRequest.of(1, CommentServiceConstant.PAGE_SIZE))).thenReturn(Page.empty());
+        when(commentRepository.findAllByNewsIdOrderByIdDesc(news.getId(), PageRequest.of(0, CommentServiceConstant.PAGE_SIZE))).thenReturn(commentPage);
+        when(commentRepository.findAllByNewsIdOrderByIdDesc(news.getId(), PageRequest.of(1, CommentServiceConstant.PAGE_SIZE))).thenReturn(Page.empty());
 
         // when
         CommentListResponse response = commentServiceImpl.getComments(news.getId(), 0);


### PR DESCRIPTION
## 연관된 이슈
#400 

<br/>

## 작업 내용
- [x] 댓글 목록 조회 리포지토리 메서드명을 최신순 정렬 방식에 맞게 변경

<br/>

## 상세 내용
### 댓글 조회 리포지토리 메서드명 변경
- **작업한 파일:** `/comment/repository/CommentRepository`
- **작업 내용:** 비즈니스 로직에 맞게 리포지토리 메서드명 수정
```java
@Repository
public interface CommentRepository extends JpaRepository<Comment, Long> {
    Page<Comment> findAllByNewsIdOrderByIdDesc(@Param("id") Long id, Pageable pageable);
}
```