### PR TITLE
feat: 카카오 OAuth 링크 상수화 및 Users 도메인의 일부 필드 중복 허용, 닉네임 중복 여부 확인 API 제거

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/auth/client/KakaoApiClientImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/client/KakaoApiClientImpl.java
@@ -2,19 +2,30 @@ package com.tamnara.backend.auth.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tamnara.backend.auth.constant.KakaoOAuthConstant;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
 
-import static com.tamnara.backend.auth.constant.AuthResponseMessage.*;
+import static com.tamnara.backend.auth.constant.AuthResponseMessage.EXTERNAL_API_TIMEOUT;
+import static com.tamnara.backend.auth.constant.AuthResponseMessage.PARSING_ACCESS_TOKEN_FAILS;
+import static com.tamnara.backend.auth.constant.AuthResponseMessage.PARSING_USER_INFO_FAILS;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoApiClientImpl implements KakaoApiClient {
@@ -27,31 +38,39 @@ public class KakaoApiClientImpl implements KakaoApiClient {
 
     @Override
     public String getAccessToken(String code) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("redirect_uri", redirectUri);
-        params.add("code", code);
-
-        HttpEntity<?> request = new HttpEntity<>(params, headers);
-
-        ResponseEntity<String> response = restTemplate.exchange(
-                "https://kauth.kakao.com/oauth/token",
-                HttpMethod.POST,
-                request,
-                String.class
-        );
-
         try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("grant_type", "authorization_code");
+            params.add("client_id", clientId);
+            params.add("redirect_uri", redirectUri);
+            params.add("code", code);
+
+            HttpEntity<?> request = new HttpEntity<>(params, headers);
+
+            ResponseEntity<String> response = restTemplate.exchange(
+                    KakaoOAuthConstant.KAKAO_OAUTH_ACCESS_TOKEN,
+                    HttpMethod.POST,
+                    request,
+                    String.class
+            );
+
             Map<String, Object> body = objectMapper.readValue(response.getBody(), Map.class);
             return (String) body.get("access_token");
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(PARSING_ACCESS_TOKEN_FAILS, e);
+        } catch (HttpClientErrorException | HttpServerErrorException e) {
+            log.error("[ERROR] 카카오 응답 오류: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new RuntimeException("카카오 요청 실패", e);
         } catch (ResourceAccessException e) {
+            log.error("[ERROR] 카카오 연결 오류: {}", e.getMessage());
             throw new RuntimeException(EXTERNAL_API_TIMEOUT, e);
+        } catch (JsonProcessingException e) {
+            log.error("[ERROR] 카카오 토큰 파싱 실패", e);
+            throw new RuntimeException(PARSING_ACCESS_TOKEN_FAILS, e);
+        } catch (Exception e) {
+            log.error("[ERROR] 알 수 없는 예외 발생", e);
+            throw new RuntimeException("알 수 없는 오류", e);
         }
     }
 
@@ -63,7 +82,7 @@ public class KakaoApiClientImpl implements KakaoApiClient {
         HttpEntity<Void> request = new HttpEntity<>(headers);
 
         ResponseEntity<String> response = restTemplate.exchange(
-                "https://kapi.kakao.com/v2/user/me",
+                KakaoOAuthConstant.KAKAO_OAUTH_USER_INFO,
                 HttpMethod.GET,
                 request,
                 String.class

--- a/backend/src/main/java/com/tamnara/backend/auth/constant/KakaoOAuthConstant.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/constant/KakaoOAuthConstant.java
@@ -1,0 +1,9 @@
+package com.tamnara.backend.auth.constant;
+
+public final class KakaoOAuthConstant {
+    private KakaoOAuthConstant() {}
+
+    public static final String KAKAO_OAUTH_AUTHORIZE = "https://kauth.kakao.com/oauth/authorize";
+    public static final String KAKAO_OAUTH_ACCESS_TOKEN = "https://kauth.kakao.com/oauth/token";
+    public static final String KAKAO_OAUTH_USER_INFO = "https://kapi.kakao.com/v2/user/me";
+}

--- a/backend/src/main/java/com/tamnara/backend/auth/service/KakaoServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/service/KakaoServiceImpl.java
@@ -1,6 +1,7 @@
 package com.tamnara.backend.auth.service;
 
 import com.tamnara.backend.auth.client.KakaoApiClient;
+import com.tamnara.backend.auth.constant.KakaoOAuthConstant;
 import com.tamnara.backend.global.constant.JwtConstant;
 import com.tamnara.backend.global.jwt.JwtProvider;
 import com.tamnara.backend.user.domain.Role;
@@ -33,7 +34,7 @@ public class KakaoServiceImpl implements KakaoService {
 
     @Override
     public String buildKakaoLoginUrl() {
-        String url = UriComponentsBuilder.fromUriString("https://kauth.kakao.com/oauth/authorize")
+        String url = UriComponentsBuilder.fromUriString(KakaoOAuthConstant.KAKAO_OAUTH_AUTHORIZE)
                 .queryParam("response_type", "code")
                 .queryParam("client_id", clientId)
                 .queryParam("redirect_uri", redirectUri)

--- a/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
@@ -1,9 +1,9 @@
 package com.tamnara.backend.user.controller;
 
-import com.tamnara.backend.global.constant.JwtConstant;
+import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.global.dto.WrappedDTO;
-import com.tamnara.backend.global.jwt.JwtProvider;
-import com.tamnara.backend.user.domain.State;
+import com.tamnara.backend.global.exception.CustomException;
+import com.tamnara.backend.user.constant.UserResponseMessage;
 import com.tamnara.backend.user.domain.User;
 import com.tamnara.backend.user.dto.EmailAvailabilityResponse;
 import com.tamnara.backend.user.dto.UserInfo;
@@ -14,19 +14,15 @@ import com.tamnara.backend.user.dto.UserWithdrawInfoWrapper;
 import com.tamnara.backend.user.exception.DuplicateUsernameException;
 import com.tamnara.backend.user.exception.InactiveUserException;
 import com.tamnara.backend.user.exception.UserNotFoundException;
-import com.tamnara.backend.user.repository.UserRepository;
 import com.tamnara.backend.user.security.UserDetailsImpl;
-import com.tamnara.backend.user.service.UserServiceImpl;
+import com.tamnara.backend.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,29 +33,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import static com.tamnara.backend.global.constant.ResponseMessage.INTERNAL_SERVER_ERROR;
-import static com.tamnara.backend.global.constant.ResponseMessage.INVALID_TOKEN;
-import static com.tamnara.backend.global.constant.ResponseMessage.USER_FORBIDDEN;
-import static com.tamnara.backend.global.constant.ResponseMessage.USER_NOT_FOUND;
-import static com.tamnara.backend.user.constant.UserResponseMessage.EMAIL_AVAILABLE;
-import static com.tamnara.backend.user.constant.UserResponseMessage.EMAIL_BAD_REQUEST;
-import static com.tamnara.backend.user.constant.UserResponseMessage.EMAIL_UNAVAILABLE;
-import static com.tamnara.backend.user.constant.UserResponseMessage.LOGOUT_SUCCESSFUL;
-import static com.tamnara.backend.user.constant.UserResponseMessage.NICKNAME_UNAVAILABLE;
-import static com.tamnara.backend.user.constant.UserResponseMessage.USER_INFO_MODIFIED;
-import static com.tamnara.backend.user.constant.UserResponseMessage.USER_INFO_RETRIEVED;
-import static com.tamnara.backend.user.constant.UserResponseMessage.WITHDRAWAL_SUCCESSFUL;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
 
-    private final UserRepository userRepository;
-    private final UserServiceImpl userService;
-    private final RedisTemplate<String, String> redisTemplate;
-    private final JwtProvider jwtProvider;
+    private final UserService userService;
 
     @GetMapping("/check-email")
     @Operation(
@@ -73,23 +54,19 @@ public class UserController {
     })
     public ResponseEntity<WrappedDTO<EmailAvailabilityResponse>> checkEmail(@RequestParam("email") String email) {
         try {
-            if (email == null || !email.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")) {
-                return ResponseEntity.badRequest().body(
-                        new WrappedDTO<>(false, EMAIL_BAD_REQUEST, null)
-                );
-            }
-
             boolean available = userService.isEmailAvailable(email);
-            return ResponseEntity.ok(
-                    new WrappedDTO<>(true,
-                            available ? EMAIL_AVAILABLE : EMAIL_UNAVAILABLE,
-                            new EmailAvailabilityResponse(available))
-            );
+            return ResponseEntity.ok(new WrappedDTO<>(
+                    true,
+                    available ? UserResponseMessage.EMAIL_AVAILABLE : UserResponseMessage.EMAIL_UNAVAILABLE,
+                    new EmailAvailabilityResponse(available)
+            ));
 
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
-            );
+        } catch (ResponseStatusException e) {
+            throw new CustomException(HttpStatus.valueOf(e.getStatusCode().value()), e.getReason());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_REQUEST);
+        } catch (RuntimeException e) {
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -108,32 +85,21 @@ public class UserController {
     })
     public ResponseEntity<WrappedDTO<UserInfoWrapper>> getCurrentUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
-            if (userDetails == null || userDetails.getUser() == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
-                        new WrappedDTO<>(false, INVALID_TOKEN, null)
-                );
-            }
-
-            Long userId = userDetails.getUser().getId();
-            UserInfo userInfo = userService.getCurrentUserInfo(userId);
+            UserInfo userInfo = userService.getCurrentUserInfo(userDetails.getUser().getId());
             UserInfoWrapper data = new UserInfoWrapper(userInfo);
 
-            return ResponseEntity.ok(
-                    new WrappedDTO<>(true, USER_INFO_RETRIEVED, data)
-            );
+            return ResponseEntity.ok(new WrappedDTO<>(
+                    true,
+                    UserResponseMessage.USER_INFO_RETRIEVED,
+                    data
+            ));
 
         } catch (InactiveUserException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
-                    new WrappedDTO<>(false, USER_FORBIDDEN, null)
-            );
+            throw new CustomException(HttpStatus.FORBIDDEN, ResponseMessage.USER_FORBIDDEN);
         } catch (UserNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    new WrappedDTO<>(false, USER_NOT_FOUND, null)
-            );
+            throw new CustomException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND);
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
-            );
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -156,35 +122,21 @@ public class UserController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         try {
-            if (userDetails == null || userDetails.getUser() == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
-                        new WrappedDTO<>(false, INVALID_TOKEN, null)
-                );
-            }
+            User updatedUser = userService.updateUsername(userDetails.getUser().getId(), dto.getNickname());
+            return ResponseEntity.ok(new WrappedDTO<>(
+                    true,
+                    UserResponseMessage.USER_INFO_MODIFIED,
+                    new UserUpdateResponse(updatedUser.getId())
+            ));
 
-            Long userId = userDetails.getUser().getId();
-            User updatedUser = userService.updateUsername(userId, dto.getNickname());
-
-            return ResponseEntity.ok(
-                    new WrappedDTO<>(true, USER_INFO_MODIFIED,
-                            new UserUpdateResponse(updatedUser.getId()))
-            );
         } catch (DuplicateUsernameException e) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(
-                    new WrappedDTO<>(false, NICKNAME_UNAVAILABLE, null)
-            );
+            throw new CustomException(HttpStatus.CONFLICT, UserResponseMessage.NICKNAME_UNAVAILABLE);
         } catch (InactiveUserException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
-                    new WrappedDTO<>(false, USER_FORBIDDEN, null)
-            );
+            throw new CustomException(HttpStatus.FORBIDDEN, ResponseMessage.USER_FORBIDDEN);
         } catch (UserNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    new WrappedDTO<>(false, USER_NOT_FOUND, null)
-            );
+            throw new CustomException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND);
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
-            );
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -203,53 +155,20 @@ public class UserController {
     })
     public ResponseEntity<WrappedDTO<Void>> logout(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            HttpServletRequest request,
             HttpServletResponse response
     ) {
         try {
-            if (userDetails == null || userDetails.getUser() == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
-                        new WrappedDTO<>(false, INVALID_TOKEN, null)
-                );
-            }
-
-            User user = userRepository.findById(userDetails.getUser().getId())
-                    .orElseThrow(UserNotFoundException::new);
-
-            if (user.getState() != State.ACTIVE) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
-                        new WrappedDTO<>(false, USER_FORBIDDEN, null)
-                );
-            }
-
-            jwtProvider.deleteRefreshToken(userDetails.getUser().getId());
-
-            Cookie expiredAccessCookie = new Cookie(JwtConstant.ACCESS_TOKEN, null);
-            expiredAccessCookie.setHttpOnly(true);
-            expiredAccessCookie.setSecure(true);
-            expiredAccessCookie.setPath("/");
-            expiredAccessCookie.setMaxAge(0);
-            response.addCookie(expiredAccessCookie);
-
-            Cookie expiredRefreshCookie = new Cookie(JwtConstant.REFRESH_TOKEN, null);
-            expiredRefreshCookie.setHttpOnly(true);
-            expiredRefreshCookie.setSecure(true);
-            expiredRefreshCookie.setPath("/");
-            expiredRefreshCookie.setMaxAge(0);
-            response.addCookie(expiredRefreshCookie);
-
-            return ResponseEntity.ok(
-                    new WrappedDTO<>(true, LOGOUT_SUCCESSFUL, null)
-            );
+            userService.logout(userDetails.getUser().getId(), response);
+            return ResponseEntity.ok(new WrappedDTO<>(
+                    true,
+                    UserResponseMessage.LOGOUT_SUCCESSFUL,
+                    null
+            ));
 
         } catch (UserNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    new WrappedDTO<>(false, USER_NOT_FOUND, null)
-            );
+            throw new CustomException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND);
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
-            );
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -268,32 +187,20 @@ public class UserController {
     })
     public ResponseEntity<WrappedDTO<UserWithdrawInfoWrapper>> withdrawUser(
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
-
         try {
-            if (userDetails == null || userDetails.getUser() == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
-                        new WrappedDTO<>(false, INVALID_TOKEN, null)
-                );
-            }
-
             UserWithdrawInfoWrapper response = userService.withdrawUser(userDetails.getUser().getId());
-
-            return ResponseEntity.ok(
-                    new WrappedDTO<>(true, WITHDRAWAL_SUCCESSFUL, response)
-            );
+            return ResponseEntity.ok(new WrappedDTO<>(
+                    true,
+                    UserResponseMessage.WITHDRAWAL_SUCCESSFUL,
+                    response
+            ));
 
         } catch (InactiveUserException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
-                    new WrappedDTO<>(false, USER_FORBIDDEN, null)
-            );
+            throw new CustomException(HttpStatus.FORBIDDEN, ResponseMessage.USER_FORBIDDEN);
         } catch (UserNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    new WrappedDTO<>(false, USER_NOT_FOUND, null)
-            );
+            throw new CustomException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND);
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
-            );
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
+++ b/backend/src/main/java/com/tamnara/backend/user/controller/UserController.java
@@ -6,7 +6,6 @@ import com.tamnara.backend.global.jwt.JwtProvider;
 import com.tamnara.backend.user.domain.State;
 import com.tamnara.backend.user.domain.User;
 import com.tamnara.backend.user.dto.EmailAvailabilityResponse;
-import com.tamnara.backend.user.dto.NicknameAvailabilityResponse;
 import com.tamnara.backend.user.dto.UserInfo;
 import com.tamnara.backend.user.dto.UserInfoWrapper;
 import com.tamnara.backend.user.dto.UserUpdateRequest;
@@ -17,7 +16,7 @@ import com.tamnara.backend.user.exception.InactiveUserException;
 import com.tamnara.backend.user.exception.UserNotFoundException;
 import com.tamnara.backend.user.repository.UserRepository;
 import com.tamnara.backend.user.security.UserDetailsImpl;
-import com.tamnara.backend.user.service.UserService;
+import com.tamnara.backend.user.service.UserServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -47,8 +46,6 @@ import static com.tamnara.backend.user.constant.UserResponseMessage.EMAIL_AVAILA
 import static com.tamnara.backend.user.constant.UserResponseMessage.EMAIL_BAD_REQUEST;
 import static com.tamnara.backend.user.constant.UserResponseMessage.EMAIL_UNAVAILABLE;
 import static com.tamnara.backend.user.constant.UserResponseMessage.LOGOUT_SUCCESSFUL;
-import static com.tamnara.backend.user.constant.UserResponseMessage.NICKNAME_AVAILABLE;
-import static com.tamnara.backend.user.constant.UserResponseMessage.NICKNAME_BAD_REQUEST;
 import static com.tamnara.backend.user.constant.UserResponseMessage.NICKNAME_UNAVAILABLE;
 import static com.tamnara.backend.user.constant.UserResponseMessage.USER_INFO_MODIFIED;
 import static com.tamnara.backend.user.constant.UserResponseMessage.USER_INFO_RETRIEVED;
@@ -60,7 +57,7 @@ import static com.tamnara.backend.user.constant.UserResponseMessage.WITHDRAWAL_S
 public class UserController {
 
     private final UserRepository userRepository;
-    private final UserService userService;
+    private final UserServiceImpl userService;
     private final RedisTemplate<String, String> redisTemplate;
     private final JwtProvider jwtProvider;
 
@@ -87,38 +84,6 @@ public class UserController {
                     new WrappedDTO<>(true,
                             available ? EMAIL_AVAILABLE : EMAIL_UNAVAILABLE,
                             new EmailAvailabilityResponse(available))
-            );
-
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().body(
-                    new WrappedDTO<>(false, INTERNAL_SERVER_ERROR, null)
-            );
-        }
-    }
-
-    @GetMapping("/check-nickname")
-    @Operation(
-            summary = "닉네임 중복 조회",
-            description = "입력된 닉네임이 이미 가입된 닉네임인지 확인합니다. 중복이면 false, 사용 가능하면 true를 반환합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "요청 성공. 사용 가능 여부는 data.available로 확인"),
-            @ApiResponse(responseCode = "400", description = "잘못된 닉네임 형식"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-    })
-    public ResponseEntity<WrappedDTO<NicknameAvailabilityResponse>> checkNickname(@RequestParam("nickname") String nickname) {
-        try {
-            if (nickname == null || nickname.isBlank() || nickname.length() > 10) {
-                return ResponseEntity.badRequest().body(
-                        new WrappedDTO<>(false, NICKNAME_BAD_REQUEST, null)
-                );
-            }
-
-            boolean available = userService.isUsernameAvailable(nickname);
-            return ResponseEntity.ok(
-                    new WrappedDTO<>(true,
-                            available ? NICKNAME_AVAILABLE : NICKNAME_UNAVAILABLE,
-                            new NicknameAvailabilityResponse(available))
             );
 
         } catch (Exception e) {

--- a/backend/src/main/java/com/tamnara/backend/user/domain/User.java
+++ b/backend/src/main/java/com/tamnara/backend/user/domain/User.java
@@ -11,9 +11,9 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "users",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_user_email", columnNames = {"email", "provider"}),
                 @UniqueConstraint(name = "uk_user_provider_id", columnNames = {"provider", "providerId"}),
-                @UniqueConstraint(name = "uk_user_username", columnNames = {"username"})
+//                @UniqueConstraint(name = "uk_user_email", columnNames = {"email", "provider"}),
+//                @UniqueConstraint(name = "uk_user_username", columnNames = {"username"})
         }
 )
 @Getter

--- a/backend/src/main/java/com/tamnara/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/tamnara/backend/user/repository/UserRepository.java
@@ -7,7 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
-    boolean existsByUsername(String username);
-    Optional<User> findByEmailAndProvider(String email, String provider);
     Optional<User> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
@@ -9,7 +9,6 @@ import com.tamnara.backend.user.dto.UserWithdrawInfoWrapper;
 public interface UserService {
     SignupResponse signup(SignupRequest requestDto);
     boolean isEmailAvailable(String email);
-    boolean isUsernameAvailable(String username);
     UserInfo getCurrentUserInfo(Long userId);
     User updateUsername(Long userId, String newUsername);
     UserWithdrawInfoWrapper withdrawUser(Long userId);

--- a/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.tamnara.backend.user.dto.SignupRequest;
 import com.tamnara.backend.user.dto.SignupResponse;
 import com.tamnara.backend.user.dto.UserInfo;
 import com.tamnara.backend.user.dto.UserWithdrawInfoWrapper;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface UserService {
     SignupResponse signup(SignupRequest requestDto);
@@ -12,4 +13,5 @@ public interface UserService {
     UserInfo getCurrentUserInfo(Long userId);
     User updateUsername(Long userId, String newUsername);
     UserWithdrawInfoWrapper withdrawUser(Long userId);
+    void logout(Long userId, HttpServletResponse response);
 }

--- a/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/UserService.java
@@ -1,140 +1,16 @@
 package com.tamnara.backend.user.service;
 
-import com.tamnara.backend.user.domain.Role;
-import com.tamnara.backend.user.domain.State;
 import com.tamnara.backend.user.domain.User;
-import com.tamnara.backend.user.dto.*;
-import com.tamnara.backend.user.exception.DuplicateEmailException;
-import com.tamnara.backend.user.exception.DuplicateUsernameException;
-import com.tamnara.backend.user.exception.InactiveUserException;
-import com.tamnara.backend.user.exception.UserNotFoundException;
-import com.tamnara.backend.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
+import com.tamnara.backend.user.dto.SignupRequest;
+import com.tamnara.backend.user.dto.SignupResponse;
+import com.tamnara.backend.user.dto.UserInfo;
+import com.tamnara.backend.user.dto.UserWithdrawInfoWrapper;
 
-import static com.tamnara.backend.user.constant.UserResponseMessage.REGISTER_SUCCESSFUL;
-
-@Slf4j
-@Service
-@RequiredArgsConstructor
-@Transactional
-public class UserService {
-
-    private final UserRepository userRepository;
-    private final PasswordEncoder passwordEncoder;
-
-    public SignupResponse signup(SignupRequest requestDto) {
-        log.info("signup 진입: email={}, username={}", requestDto.getEmail(), requestDto.getUsername());
-        if (userRepository.existsByEmail(requestDto.getEmail())) {
-            log.warn("이메일 중복: {}", requestDto.getEmail());
-            throw new DuplicateEmailException();
-        }
-        if (userRepository.existsByUsername(requestDto.getUsername())) {
-            log.warn("닉네임 중복: {}", requestDto.getUsername());
-            throw new DuplicateUsernameException();
-        }
-
-        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
-
-        User user = User.builder()
-                .email(requestDto.getEmail())
-                .password(encodedPassword)
-                .username(requestDto.getUsername())
-                .provider("LOCAL")
-                .providerId(null)
-                .role(Role.USER)
-                .state(State.ACTIVE)
-                .build();
-
-        User savedUser = userRepository.save(user);
-        log.info("회원가입 성공: userId={}", savedUser.getId());
-
-        return SignupResponse.builder()
-                .success(true)
-                .message(REGISTER_SUCCESSFUL)
-                .data(SignupResponse.UserData.builder()
-                        .userId(savedUser.getId())
-                        .build())
-                .build();
-    }
-
-    public boolean isEmailAvailable(String email) {
-        boolean result = !userRepository.existsByEmail(email);
-        log.info("이메일 사용 가능 여부: email={}, available={}", email, result);
-        return result;
-    }
-
-    public boolean isUsernameAvailable(String username) {
-        boolean result = !userRepository.existsByUsername(username);
-        log.info("닉네임 사용 가능 여부: username={}, available={}", username, result);
-        return result;
-    }
-
-    public UserInfo getCurrentUserInfo(Long userId) {
-        log.info("getCurrentUserInfo 진입: userId={}", userId);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> {
-                    log.error("회원 조회 실패: userId={}", userId);
-                    return new UserNotFoundException();
-                });
-
-        if (user.getState() != State.ACTIVE) {
-            log.warn("비활성 회원 접근 차단: userId={}, state={}", user.getId(), user.getState());
-            throw new InactiveUserException(); // DELETED나 INACTIVE는 허용하지 않음
-        }
-
-        return new UserInfo(user.getId(), user.getEmail(), user.getUsername());
-    }
-
-    @Transactional
-    public User updateUsername(Long userId, String newUsername) {
-        log.info("updateUsername 진입: userId={}, newUsername={}", userId, newUsername);
-
-        if (userRepository.existsByUsername(newUsername)) {
-            log.warn("닉네임 중복: {}", newUsername);
-            throw new DuplicateUsernameException();
-        }
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> {
-                    log.error("회원 조회 실패: userId={}", userId);
-                    return new UserNotFoundException();
-                });
-
-        if (user.getState() != State.ACTIVE) {
-            log.warn("비활성 회원 접근 차단: userId={}, state={}", user.getId(), user.getState());
-            throw new InactiveUserException();
-        }
-
-        user.updateUsername(newUsername);
-        log.info("닉네임 변경 성공: userId={}, updatedUsername={}", userId, newUsername);
-
-        return user;
-    }
-
-    public UserWithdrawInfoWrapper withdrawUser(Long userId) {
-        log.info("withdrawUser 진입: userId={}", userId);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> {
-                    log.error("회원 조회 실패: userId={}", userId);
-                    return new UserNotFoundException();
-                });
-
-        if (user.getState() != State.ACTIVE) {
-            log.warn("비활성 회원 접근 차단: userId={}, state={}", user.getId(), user.getState());
-            throw new InactiveUserException();
-        }
-
-        user.softDelete();
-        log.info("회원 탈퇴 처리 완료: userId={}, withdrawnAt={}", user.getId(), user.getWithdrawnAt());
-
-        return new UserWithdrawInfoWrapper(
-                new UserWithdrawInfo(user.getId(), user.getWithdrawnAt())
-        );
-    }
+public interface UserService {
+    SignupResponse signup(SignupRequest requestDto);
+    boolean isEmailAvailable(String email);
+    boolean isUsernameAvailable(String username);
+    UserInfo getCurrentUserInfo(Long userId);
+    User updateUsername(Long userId, String newUsername);
+    UserWithdrawInfoWrapper withdrawUser(Long userId);
 }

--- a/backend/src/main/java/com/tamnara/backend/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/UserServiceImpl.java
@@ -3,9 +3,12 @@ package com.tamnara.backend.user.service;
 import com.tamnara.backend.user.domain.Role;
 import com.tamnara.backend.user.domain.State;
 import com.tamnara.backend.user.domain.User;
-import com.tamnara.backend.user.dto.*;
+import com.tamnara.backend.user.dto.SignupRequest;
+import com.tamnara.backend.user.dto.SignupResponse;
+import com.tamnara.backend.user.dto.UserInfo;
+import com.tamnara.backend.user.dto.UserWithdrawInfo;
+import com.tamnara.backend.user.dto.UserWithdrawInfoWrapper;
 import com.tamnara.backend.user.exception.DuplicateEmailException;
-import com.tamnara.backend.user.exception.DuplicateUsernameException;
 import com.tamnara.backend.user.exception.InactiveUserException;
 import com.tamnara.backend.user.exception.UserNotFoundException;
 import com.tamnara.backend.user.repository.UserRepository;
@@ -32,10 +35,6 @@ public class UserServiceImpl implements UserService {
         if (userRepository.existsByEmail(requestDto.getEmail())) {
             log.warn("이메일 중복: {}", requestDto.getEmail());
             throw new DuplicateEmailException();
-        }
-        if (userRepository.existsByUsername(requestDto.getUsername())) {
-            log.warn("닉네임 중복: {}", requestDto.getUsername());
-            throw new DuplicateUsernameException();
         }
 
         String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
@@ -70,13 +69,6 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public boolean isUsernameAvailable(String username) {
-        boolean result = !userRepository.existsByUsername(username);
-        log.info("닉네임 사용 가능 여부: username={}, available={}", username, result);
-        return result;
-    }
-
-    @Override
     public UserInfo getCurrentUserInfo(Long userId) {
         log.info("getCurrentUserInfo 진입: userId={}", userId);
 
@@ -98,11 +90,6 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public User updateUsername(Long userId, String newUsername) {
         log.info("updateUsername 진입: userId={}, newUsername={}", userId, newUsername);
-
-        if (userRepository.existsByUsername(newUsername)) {
-            log.warn("닉네임 중복: {}", newUsername);
-            throw new DuplicateUsernameException();
-        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> {

--- a/backend/src/main/java/com/tamnara/backend/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/UserServiceImpl.java
@@ -1,0 +1,146 @@
+package com.tamnara.backend.user.service;
+
+import com.tamnara.backend.user.domain.Role;
+import com.tamnara.backend.user.domain.State;
+import com.tamnara.backend.user.domain.User;
+import com.tamnara.backend.user.dto.*;
+import com.tamnara.backend.user.exception.DuplicateEmailException;
+import com.tamnara.backend.user.exception.DuplicateUsernameException;
+import com.tamnara.backend.user.exception.InactiveUserException;
+import com.tamnara.backend.user.exception.UserNotFoundException;
+import com.tamnara.backend.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import static com.tamnara.backend.user.constant.UserResponseMessage.REGISTER_SUCCESSFUL;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public SignupResponse signup(SignupRequest requestDto) {
+        log.info("signup 진입: email={}, username={}", requestDto.getEmail(), requestDto.getUsername());
+        if (userRepository.existsByEmail(requestDto.getEmail())) {
+            log.warn("이메일 중복: {}", requestDto.getEmail());
+            throw new DuplicateEmailException();
+        }
+        if (userRepository.existsByUsername(requestDto.getUsername())) {
+            log.warn("닉네임 중복: {}", requestDto.getUsername());
+            throw new DuplicateUsernameException();
+        }
+
+        String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+        User user = User.builder()
+                .email(requestDto.getEmail())
+                .password(encodedPassword)
+                .username(requestDto.getUsername())
+                .provider("LOCAL")
+                .providerId(null)
+                .role(Role.USER)
+                .state(State.ACTIVE)
+                .build();
+
+        User savedUser = userRepository.save(user);
+        log.info("회원가입 성공: userId={}", savedUser.getId());
+
+        return SignupResponse.builder()
+                .success(true)
+                .message(REGISTER_SUCCESSFUL)
+                .data(SignupResponse.UserData.builder()
+                        .userId(savedUser.getId())
+                        .build())
+                .build();
+    }
+
+    @Override
+    public boolean isEmailAvailable(String email) {
+        boolean result = !userRepository.existsByEmail(email);
+        log.info("이메일 사용 가능 여부: email={}, available={}", email, result);
+        return result;
+    }
+
+    @Override
+    public boolean isUsernameAvailable(String username) {
+        boolean result = !userRepository.existsByUsername(username);
+        log.info("닉네임 사용 가능 여부: username={}, available={}", username, result);
+        return result;
+    }
+
+    @Override
+    public UserInfo getCurrentUserInfo(Long userId) {
+        log.info("getCurrentUserInfo 진입: userId={}", userId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.error("회원 조회 실패: userId={}", userId);
+                    return new UserNotFoundException();
+                });
+
+        if (user.getState() != State.ACTIVE) {
+            log.warn("비활성 회원 접근 차단: userId={}, state={}", user.getId(), user.getState());
+            throw new InactiveUserException(); // DELETED나 INACTIVE는 허용하지 않음
+        }
+
+        return new UserInfo(user.getId(), user.getEmail(), user.getUsername());
+    }
+
+    @Override
+    @Transactional
+    public User updateUsername(Long userId, String newUsername) {
+        log.info("updateUsername 진입: userId={}, newUsername={}", userId, newUsername);
+
+        if (userRepository.existsByUsername(newUsername)) {
+            log.warn("닉네임 중복: {}", newUsername);
+            throw new DuplicateUsernameException();
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.error("회원 조회 실패: userId={}", userId);
+                    return new UserNotFoundException();
+                });
+
+        if (user.getState() != State.ACTIVE) {
+            log.warn("비활성 회원 접근 차단: userId={}, state={}", user.getId(), user.getState());
+            throw new InactiveUserException();
+        }
+
+        user.updateUsername(newUsername);
+        log.info("닉네임 변경 성공: userId={}, updatedUsername={}", userId, newUsername);
+
+        return user;
+    }
+
+    @Override
+    public UserWithdrawInfoWrapper withdrawUser(Long userId) {
+        log.info("withdrawUser 진입: userId={}", userId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.error("회원 조회 실패: userId={}", userId);
+                    return new UserNotFoundException();
+                });
+
+        if (user.getState() != State.ACTIVE) {
+            log.warn("비활성 회원 접근 차단: userId={}, state={}", user.getId(), user.getState());
+            throw new InactiveUserException();
+        }
+
+        user.softDelete();
+        log.info("회원 탈퇴 처리 완료: userId={}, withdrawnAt={}", user.getId(), user.getWithdrawnAt());
+
+        return new UserWithdrawInfoWrapper(
+                new UserWithdrawInfo(user.getId(), user.getWithdrawnAt())
+        );
+    }
+}

--- a/backend/src/test/java/com/tamnara/backend/auth/controller/KakaoControllerIntegrationTest.java
+++ b/backend/src/test/java/com/tamnara/backend/auth/controller/KakaoControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.tamnara.backend.auth.controller;
 import com.tamnara.backend.auth.client.KakaoApiClient;
 import com.tamnara.backend.auth.config.KakaoApiClientMockConfig;
 import com.tamnara.backend.global.constant.JwtConstant;
+import com.tamnara.backend.global.constant.ResponseMessage;
 import com.tamnara.backend.user.domain.User;
 import com.tamnara.backend.user.repository.UserRepository;
 import org.hamcrest.Matchers;
@@ -21,7 +22,6 @@ import java.util.Map;
 
 import static com.tamnara.backend.auth.constant.AuthResponseMessage.KAKAO_BAD_GATEWAY;
 import static com.tamnara.backend.auth.constant.AuthResponseMessage.PARSING_USER_INFO_FAILS;
-import static com.tamnara.backend.global.constant.ResponseMessage.USER_NOT_FOUND;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -38,7 +38,6 @@ class KakaoControllerIntegrationTest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private KakaoApiClient kakaoApiClient;
-
     @Autowired private UserRepository userRepository;
 
     @AfterEach
@@ -74,8 +73,7 @@ class KakaoControllerIntegrationTest {
     @DisplayName("카카오 access token 발급 실패 시 500 응답을 반환한다")
     void kakaoCallback_AccessTokenFailure_returnsBadGateway() throws Exception {
         // given
-        when(kakaoApiClient.getAccessToken(anyString()))
-                .thenThrow(new RuntimeException(KAKAO_BAD_GATEWAY));
+        when(kakaoApiClient.getAccessToken(anyString())).thenThrow(new RuntimeException(KAKAO_BAD_GATEWAY));
 
         // when & then
         mockMvc.perform(get("/auth/kakao/callback")
@@ -89,9 +87,7 @@ class KakaoControllerIntegrationTest {
     @DisplayName("카카오 사용자 정보 파싱 실패 시 500 응답을 반환한다")
     void kakaoCallback_UserInfoParsingFailure_returnsInternalServerError() throws Exception {
         // given
-        when(kakaoApiClient.getAccessToken(anyString()))
-                .thenReturn("mockAccessToken");
-
+        when(kakaoApiClient.getAccessToken(anyString())).thenReturn("mockAccessToken");
         when(kakaoApiClient.getUserInfo("mockAccessToken")).thenThrow(new RuntimeException(PARSING_USER_INFO_FAILS));
 
         // when & then
@@ -106,9 +102,8 @@ class KakaoControllerIntegrationTest {
     @DisplayName("기존 사용자가 카카오 로그인 시 토큰 발급 및 활동시간 업데이트에 성공한다")
     void kakaoCallback_existingUser_success() throws Exception {
         // given
-        User existingUser = userRepository.findByEmailAndProvider("test@kakao.com", "KAKAO")
-                .orElseThrow(() -> new IllegalArgumentException(USER_NOT_FOUND));
-
+        User existingUser = userRepository.findByProviderAndProviderId("KAKAO", "12345")
+                .orElseThrow(() -> new IllegalArgumentException(ResponseMessage.USER_NOT_FOUND));
         userRepository.save(existingUser);
 
         when(kakaoApiClient.getAccessToken(anyString())).thenReturn("mockAccessToken");

--- a/backend/src/test/java/com/tamnara/backend/user/controller/UserControllerIntegrationTest.java
+++ b/backend/src/test/java/com/tamnara/backend/user/controller/UserControllerIntegrationTest.java
@@ -104,37 +104,6 @@ public class UserControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("닉네임 중복 조회 - available")
-    void checkNickname_available() throws Exception {
-        // when & then
-        mockMvc.perform(get("/users/check-nickname")
-                        .param("nickname", "uniqueNick"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.available").value(true))
-                .andExpect(jsonPath("$.message").value(NICKNAME_AVAILABLE));
-    }
-
-    @Test
-    @DisplayName("닉네임 중복 조회 - conflict")
-    void checkNickname_conflict() throws Exception {
-        // given
-        userRepository.save(User.builder()
-                .email("another@example.com")
-                .username("dupeNick")
-                .provider("KAKAO")
-                .role(Role.USER)
-                .state(State.ACTIVE)
-                .build());
-
-        // when & then
-        mockMvc.perform(get("/users/check-nickname")
-                        .param("nickname", "dupeNick"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.available").value(false))
-                .andExpect(jsonPath("$.message").value(NICKNAME_UNAVAILABLE));
-    }
-
-    @Test
     @DisplayName("회원 정보 조회 통합 테스트 - 성공")
     void getCurrentUser_success() throws Exception {
         // when & then
@@ -196,29 +165,6 @@ public class UserControllerIntegrationTest {
                         .content(objectMapper.writeValueAsString(dto)))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.message").value(USER_FORBIDDEN));
-    }
-
-    @Test
-    @DisplayName("회원 정보 수정 실패 - 중복 닉네임")
-    void updateNickname_conflict() throws Exception {
-        // given
-        userRepository.save(User.builder()
-                .email("another@example.com")
-                .username("dupeNick")
-                .provider("KAKAO")
-                .role(Role.USER)
-                .state(State.ACTIVE)
-                .build());
-
-        UserUpdateRequest dto = new UserUpdateRequest("dupeNick");
-
-        // when & then
-        mockMvc.perform(patch("/users/me")
-                        .header("Authorization", getAccessToken(user))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.message").value(NICKNAME_UNAVAILABLE));
     }
 
     @Test

--- a/backend/src/test/java/com/tamnara/backend/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/tamnara/backend/user/repository/UserRepositoryTest.java
@@ -55,35 +55,6 @@ class UserRepositoryTest {
     }
 
     @Test
-    @DisplayName("닉네임 중복 여부 확인")
-    void existsByUsername_success() {
-        // given
-        User user = createTestUser();
-        userRepository.save(user);
-
-        // when
-        boolean exists = userRepository.existsByUsername("탐라유저");
-
-        // then
-        assertThat(exists).isTrue();
-    }
-
-    @Test
-    @DisplayName("이메일과 provider로 회원 조회")
-    void findByEmailAndProvider_success() {
-        // given
-        User user = createTestUser();
-        userRepository.save(user);
-
-        // when
-        Optional<User> result = userRepository.findByEmailAndProvider("test@example.com", "LOCAL");
-
-        // then
-        assertThat(result).isPresent();
-        assertThat(result.get().getUsername()).isEqualTo("탐라유저");
-    }
-
-    @Test
     @DisplayName("provider와 providerId로 유저 조회")
     void findByProviderAndProviderId_success() {
         // given

--- a/backend/src/test/java/com/tamnara/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/tamnara/backend/user/service/UserServiceTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
-    @InjectMocks private UserService userService;
+    @InjectMocks private UserServiceImpl userService;
     @Mock private UserRepository userRepository;
 
     @Test
@@ -37,16 +37,6 @@ class UserServiceTest {
 
         // when, then
         assertThat(userService.isEmailAvailable("a@a.com")).isTrue();
-    }
-
-    @Test
-    @DisplayName("닉네임 사용 가능 여부 확인")
-    void isUsernameAvailable_success() {
-        // given
-        Mockito.when(userRepository.existsByUsername("탐라")).thenReturn(true);
-
-        // when, then
-        assertThat(userService.isUsernameAvailable("탐라")).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/com/tamnara/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/tamnara/backend/user/service/UserServiceTest.java
@@ -5,7 +5,6 @@ import com.tamnara.backend.user.domain.User;
 import com.tamnara.backend.user.dto.UserInfo;
 import com.tamnara.backend.user.dto.UserWithdrawInfo;
 import com.tamnara.backend.user.dto.UserWithdrawInfoWrapper;
-import com.tamnara.backend.user.exception.DuplicateUsernameException;
 import com.tamnara.backend.user.exception.InactiveUserException;
 import com.tamnara.backend.user.exception.UserNotFoundException;
 import com.tamnara.backend.user.repository.UserRepository;
@@ -82,7 +81,6 @@ class UserServiceTest {
                 .username("old")
                 .state(State.ACTIVE)
                 .build();
-        Mockito.when(userRepository.existsByUsername("new")).thenReturn(false);
         Mockito.when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // when
@@ -90,17 +88,6 @@ class UserServiceTest {
 
         // then
         assertThat(result.getUsername()).isEqualTo("new");
-    }
-
-    @Test
-    @DisplayName("닉네임이 중복 시 변경 불가")
-    void updateUsername_duplicate_throwsException_success() {
-        // given
-        Mockito.when(userRepository.existsByUsername("existing")).thenReturn(true);
-
-        // when, then
-        assertThatThrownBy(() -> userService.updateUsername(1L, "existing"))
-                .isInstanceOf(DuplicateUsernameException.class);
     }
 
     @Test


### PR DESCRIPTION
## 연관된 이슈
#405 #407 #409 

<br/>

## 작업 내용
- [x] 카카오 OAuth 요청 URL 상수화 (인가 코드, 액세스 토큰, 사용자 정보 조회)
- [x] refactor: User 도메인에서 email, username 필드의 unique 제약 제거
- [x] 닉네임 중복 여부 확인 API 제거
- [x] 닉네임 중복 여부 확인 서비스 및 서비스 내부 로직 제거
- [x] 닉네임 중복 여부 확인 리포지토리 메서드 제거
- [x] 닉네임 중복 여부 확인 로직을 테스트 코드에서 제거
- [x] UserService 클래스를 UserService 인터페이스와 UserServiceImpl 클래스로 분리
- [x] UserController의 비즈니스 로직을 UserService로 분리

<br/>

## 상세 내용
### 닉네임 중복 여부 확인 리포지토리 메서드 제거
- **작업한 파일:** `user.repository.UserRepository`
- **작업 내용**
   - `existsByUsername()`(닉네임 존재 여부 확인 메서드) 제거
   - 이메일 중복 허용에 따라 `findByEmailAndProvider()`(이메일과 Provider로 회원 조회 메서드) 제거
   - 서비스 로직에서 해당 리포지토리 메서드를 호출하는 코드 제거

<br/>

### 닉네임 중복 여부 확인 서비스 및 서비스 내부 로직 제거
- **작업한 파일:** `user.service.UserService`, `user.service.UserServiceImpl`
- **작업 내용**
   - `isUsernameAvailable()`(닉네임 사용 가능 여부 확인 서비스 메서드) 제거
   - 회원가입, 회원정보 수정 서비스에서 닉네임 중복 여부 확인 로직 제거

<br/>

### 닉네임 중복 여부 확인 API 제거
- **작업한 파일:** `user.controller.UserController`
- **작업 내용**
   - `/users/check-nickname` 엔드포인트에 해당하는 API 제거