### PR TITLE
feat: NewsDetailDTO에 카테고리(category) 필드 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/news/dto/NewsDetailDTO.java
+++ b/backend/src/main/java/com/tamnara/backend/news/dto/NewsDetailDTO.java
@@ -18,6 +18,7 @@ public class NewsDetailDTO {
     private String title;
     @Length(max = 255, message = "이미지 링크의 길이가 너무 깁니다.")
     private String image;
+    private String category;
     @PastOrPresent(message = "날짜는 과거 또는 현재만 가능합니다.")
     private LocalDateTime updatedAt;
     private boolean bookmarked;

--- a/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/news/service/NewsServiceImpl.java
@@ -211,6 +211,7 @@ public class NewsServiceImpl implements NewsService {
                 news.getId(),
                 news.getTitle(),
                 image,
+                news.getCategory().getName().toString(),
                 news.getUpdatedAt(),
                 bookmarked,
                 timelineCardDTOList,
@@ -335,6 +336,7 @@ public class NewsServiceImpl implements NewsService {
                 news.getId(),
                 news.getTitle(),
                 newsImage.getUrl(),
+                news.getCategory().getName().toString(),
                 news.getUpdatedAt(),
                 true,
                 timeline,
@@ -371,6 +373,7 @@ public class NewsServiceImpl implements NewsService {
             timelineCard.setNews(news);
             timelineCard.setTitle(dto.getTitle());
             timelineCard.setContent(dto.getContent());
+            timelineCard.setSource(dto.getSource());
             timelineCard.setDuration(TimelineCardType.DAY);
             timelineCard.setStartAt(dto.getStartAt());
             timelineCard.setEndAt(dto.getEndAt());
@@ -381,6 +384,7 @@ public class NewsServiceImpl implements NewsService {
           news.getId(),
           news.getTitle(),
           req.getImage(),
+          news.getCategory().getName().toString(),
           news.getUpdatedAt(),
           false,
           req.getTimeline(),
@@ -409,6 +413,7 @@ public class NewsServiceImpl implements NewsService {
                         news.getId(),
                         news.getTitle(),
                         news.getSummary(),
+                        news.getCategory().getName().toString(),
                         news.getUpdatedAt(),
                         false,
                         getTimelineCardDTOList(news),
@@ -524,6 +529,7 @@ public class NewsServiceImpl implements NewsService {
                 news.getId(),
                 news.getTitle(),
                 updatedNewsImage.getUrl(),
+                news.getCategory().getName().toString(),
                 news.getUpdatedAt(),
                 true,
                 newTimeline,

--- a/backend/src/test/java/com/tamnara/backend/news/controller/NewsControllerTest.java
+++ b/backend/src/test/java/com/tamnara/backend/news/controller/NewsControllerTest.java
@@ -76,7 +76,7 @@ public class NewsControllerTest {
                 bookmarked,
                 bookmarked ? LocalDateTime.now() : null
         );
-    };
+    }
 
     private TimelineCardDTO createTimelineCardDTO() {
         return new TimelineCardDTO(
@@ -97,12 +97,13 @@ public class NewsControllerTest {
                 id,
                 "제목",
                 "이미지 링크",
+                CategoryType.SPORTS.name(),
                 LocalDateTime.now(),
                 bookmarked,
                 List.of(timelineCardDTO1, timelineCardDTO2),
                 new StatisticsDTO(50, 30, 20)
         );
-    };
+    }
 
     @BeforeEach
     void setupSecurityContext() {


### PR DESCRIPTION
## 연관된 이슈
#408 

<br/>

## 작업 내용
- [ ] NewsDetailDTO에 category 필드 추가
- [ ] NewsServiceImpl에서 DTO 인스턴스에 category 필드 데이터 추가
- [ ] 테스트 코드에 변경된 서비스 로직 반영

<br/>

## 상세 내용
## NewsDetailDTO에 카테고리 필드 추가
- **작업한 파일:** `news.dto.NewsDetailDTO`, `news.service.NewsServiceImpl`
- **작업 내용**
   - DTO에 필드 추가
   - 서비스 로직에서 DTO 인스턴스에 카테고리 추가
```java
@Getter
@AllArgsConstructor
public class NewsDetailDTO {
    ...
    private String category;
    ...
}
```

```java
return new NewsDetailDTO(
        ...
        news.getCategory().getName().toString(),
        ...
);
```