### PR TITLE
fix: 댓글 조회 시 작성자 없을 때 null 처리 분기 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/comment/service/CommentServiceImpl.java
@@ -46,8 +46,8 @@ public class CommentServiceImpl implements CommentService {
         for (Comment c : comments.getContent()) {
             CommentDTO dto = new CommentDTO(
                     c.getId(),
-                    c.getUser().getId(),
-                    c.getUser().getUsername(),
+                    c.getUser() != null ? c.getUser().getId() : null,
+                    c.getUser() != null ? c.getUser().getUsername() : null,
                     c.getContent(),
                     c.getCreatedAt()
             );


### PR DESCRIPTION
## 연관된 이슈
#411 

<br/>

## 작업 내용
- [x] 댓글 조회 서비스 로직에서 CommentDTO에 작성자 정보가 없을 때 처리하는 삼항 연산자 추가

<br/>

## 상세 내용
- **작업한 파일:** `comment.service.CommentServiceImpl`
- **작업 내용**
```java
for (Comment c : comments.getContent()) {
    CommentDTO dto = new CommentDTO(
            ...
            c.getUser() != null ? c.getUser().getId() : null,
            c.getUser() != null ? c.getUser().getUsername() : null,
           ...
    );
    commentDTOList.add(dto);
}
```