### PR TITLE
feat: 인증 기능의 서비스 로직에 로깅 추가

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import com.tamnara.backend.user.security.UserDetailsImpl;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -29,7 +31,9 @@ public class AuthController {
     @GetMapping("/check")
     public ResponseEntity<WrappedDTO<CheckAuthResponse>> checkAuth(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         try {
+            log.info("[AUTH] checkAuth 요청 시작");
             if (userDetails == null) {
+                log.info("[AUTH] checkAuth 완료 — status={}", "로그아웃");
                 return ResponseEntity.ok(new WrappedDTO<>(
                         false,
                         AuthResponseMessage.NOT_LOGGED_IN,
@@ -37,6 +41,7 @@ public class AuthController {
                 ));
             }
 
+            log.info("[AUTH] checkAuth 완료 — status={}, userId: {}", "로그인", userDetails.getUser().getId());
             return ResponseEntity.ok(new WrappedDTO<>(
                     true,
                     AuthResponseMessage.IS_LOGGED_IN,

--- a/backend/src/main/java/com/tamnara/backend/auth/service/AuthServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/service/AuthServiceImpl.java
@@ -11,9 +11,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthServiceImpl implements AuthService {
@@ -23,24 +25,34 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public void refreshToken(HttpServletRequest request, HttpServletResponse response) {
+        log.info("[AUTH] refreshToken 요청 시작");
+
         String refreshToken = jwtProvider.resolveRefreshTokenFromCookie(request);
 
-        if (refreshToken == null || !jwtProvider.validateRefreshToken(refreshToken)) {
+        if (refreshToken == null) {
+            log.warn("[AUTH] refreshToken 완료 — status={}, reason={}", "실패", "토큰 없음");
+            throw new CustomException(HttpStatus.UNAUTHORIZED, AuthResponseMessage.REFRESH_TOKEN_INVALID);
+        } else if (!jwtProvider.validateRefreshToken(refreshToken)) {
+            log.warn("[AUTH] refreshToken 완료 — status={}, reason={}", "실패", "유효하지 않은 토큰");
             throw new CustomException(HttpStatus.UNAUTHORIZED, AuthResponseMessage.REFRESH_TOKEN_INVALID);
         }
 
         String userId = jwtProvider.getUserIdFromToken(refreshToken);
         User user = userRepository.findById(Long.parseLong(userId))
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
+        log.info("[AUTH] refreshToken 처리 중 — 회원 조회 완료, userId: {}", userId);
 
         String newAccessToken = jwtProvider.createAccessToken(user);
+        log.info("[AUTH] refreshToken 처리 중 - 새로운 Access Token 발급, userId: {}", userId);
 
         Cookie newAccessCookie = new Cookie(JwtConstant.ACCESS_TOKEN, newAccessToken);
         newAccessCookie.setHttpOnly(true);
         newAccessCookie.setSecure(true);
         newAccessCookie.setPath("/");
         newAccessCookie.setMaxAge((int) JwtConstant.ACCESS_TOKEN_VALIDITY.toSeconds());
-
         response.addCookie(newAccessCookie);
+        log.info("[AUTH] refreshToken 처리 중 - 새로운 Access Token 쿠키 저장, userId: {}", userId);
+
+        log.info("[AUTH] refreshToken() 완료 - status:{}", "성공");
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/auth/service/KakaoServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/service/KakaoServiceImpl.java
@@ -34,6 +34,8 @@ public class KakaoServiceImpl implements KakaoService {
 
     @Override
     public String buildKakaoLoginUrl() {
+        log.info("[AUTH] buildKakaoLoginUrl 요청 시작");
+
         String url = UriComponentsBuilder.fromUriString(KakaoOAuthConstant.KAKAO_OAUTH_AUTHORIZE)
                 .queryParam("response_type", "code")
                 .queryParam("client_id", clientId)
@@ -41,20 +43,20 @@ public class KakaoServiceImpl implements KakaoService {
                 .build()
                 .toUriString();
 
-        log.info("[INFO] 카카오 로그인 URL 생성: {}", url);
+        log.info("[AUTH] buildKakaoLoginUrl 완료");
         return url;
     }
 
     @Override
     @Transactional
     public void kakaoLogin(String code, HttpServletResponse response) {
-        log.info("[INFO] 카카오 로그인 시작: code={}", code);
+        log.info("[AUTH] kakaoLogin 요청 시작");
 
-        String accessToken = kakaoApiClient.getAccessToken(code);
-        log.info("[INFO] 카카오 access token 발급 성공");
+        String kakaoAccessToken = kakaoApiClient.getAccessToken(code);
+        log.info("[AUTH] kakaoLogin 처리 중 - 카카오 Access Token 발급 성공");
 
-        Map<String, Object> userInfoJson = kakaoApiClient.getUserInfo(accessToken);
-        log.info("[INFO] 카카오 사용자 정보 조회 성공");
+        Map<String, Object> userInfoJson = kakaoApiClient.getUserInfo(kakaoAccessToken);
+        log.info("[AUTH] kakaoLogin 처리 중 - 카카오 사용자 정보 조회 성공");
 
         Map<String, Object> kakaoAccount = (Map<String, Object>) userInfoJson.get("kakao_account");
         Map<String, Object> properties = (Map<String, Object>) userInfoJson.get("properties");
@@ -62,7 +64,7 @@ public class KakaoServiceImpl implements KakaoService {
         String kakaoId = String.valueOf(userInfoJson.get("id"));
         String email = (String) kakaoAccount.get("email");
         String nickname = (String) properties.get("nickname");
-        log.debug("[INFO] 카카오 사용자 파싱 결과: kakaoId={}, email={}, nickname={}", kakaoId, email, nickname);
+        log.info("[AUTH] kakaoLogin 처리 중 - 카카오 사용자 파싱 완료, kakaoId={}", kakaoId);
 
         Optional<User> optionalUser = userRepository.findByProviderAndProviderId("KAKAO", kakaoId);
         User user;
@@ -71,6 +73,7 @@ public class KakaoServiceImpl implements KakaoService {
             if (user.getState().equals(State.DELETED)) {
                 user.updateState(State.ACTIVE);
                 user.resetWithdrawnAtNull();
+                log.info("[AUTH] kakaoLogin 처리 중 - 탈퇴한 계정 복구, userId: {}", user.getId());
             }
         } else {
             user = optionalUser.orElseGet(() -> User.builder()
@@ -82,32 +85,33 @@ public class KakaoServiceImpl implements KakaoService {
                 .state(State.ACTIVE)
                 .build());
         }
-
         user.updateLastActiveAtNow();
         userRepository.save(user);
-        log.info("[INFO] 마지막 활동시간 업데이트 완료: userId={}", user.getId());
+        log.info("[AUTH] kakaoLogin 처리 중 - 마지막 활동시간 업데이트 완료, userId: {}", user.getId());
 
-        String tamnaraAccessToken = jwtProvider.createAccessToken(user);
-        log.info("[INFO] JWT access token 발급 완료: userId={}", user.getId());
+        String accessToken = jwtProvider.createAccessToken(user);
+        log.info("[AUTH] kakaoLogin 처리 중 - JWT Access Token 발급 완료, userId: {}", user.getId());
 
-        Cookie accessCookie = new Cookie(JwtConstant.ACCESS_TOKEN, tamnaraAccessToken);
+        String refreshToken = jwtProvider.createRefreshToken(user);
+        jwtProvider.saveRefreshToken(user, refreshToken);
+        log.info("[AUTH] kakaoLogin 처리 중 - JWT Refresh Token 발급 완료, userId: {}", user.getId());
+
+        Cookie accessCookie = new Cookie(JwtConstant.ACCESS_TOKEN, accessToken);
         accessCookie.setHttpOnly(true);
         accessCookie.setSecure(true);
         accessCookie.setPath("/");
         accessCookie.setMaxAge((int) JwtConstant.ACCESS_TOKEN_VALIDITY.getSeconds());
         response.addCookie(accessCookie);
-        log.info("[INFO] 쿠키에 JWT access token 저장 완료: userId={}", user.getId());
+        log.info("[AUTH] kakaoLogin 처리 중 - 쿠키에 JWT Access Token 저장 완료, userId: {}", user.getId());
 
-        String tamnaraRefreshToken = jwtProvider.createRefreshToken(user);
-        jwtProvider.saveRefreshToken(user, tamnaraRefreshToken);
-        log.info("[INFO] JWT refresh token 발급 완료: userId={}", user.getId());
-
-        Cookie refreshCookie = new Cookie(JwtConstant.REFRESH_TOKEN, tamnaraRefreshToken);
+        Cookie refreshCookie = new Cookie(JwtConstant.REFRESH_TOKEN, refreshToken);
         refreshCookie.setHttpOnly(true);
         refreshCookie.setSecure(true);
         refreshCookie.setPath("/");
         refreshCookie.setMaxAge((int) JwtConstant.REFRESH_TOKEN_VALIDITY.getSeconds());
         response.addCookie(refreshCookie);
-        log.info("[INFO] 쿠키에 JWT refresh token 저장 완료: userId={}", user.getId());
+        log.info("[AUTH] kakaoLogin 처리 중 - 쿠키에 JWT Refresh Token 저장 완료: userId={}", user.getId());
+
+        log.info("[AUTH] kakaoLogin 완료 - userId: {}",  user.getId());
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#475 

<br/>

## 작업 내용
- [x] 인증 상태 확인 API 컨트롤러 내부 로깅 추가
- [x] JWT Refresh Token 재발급 서비스 로깅 추가
- [x] 카카오 로그인 URL 생성 서비스 로깅 추가
- [x] 카카오 로그인 서비스 로깅 추가

<br/>

## 상세 내용
- **작업한 파일:**
   - `auth.controller.AuthController`
   - `auth.service.AuthServiceImpl`
   - `auth.service.KakaoServiceImpl`
- **작업 내용**
   - 클래스에 `@Slf4j` 어노테이션 추가
   - `log.info`/`log.warn`/`log.error` 로깅 추가
   - 포맷: `[기능] 서비스 메서드 (시작/처리 중/완료) - 세부 로그` 