### PR TITLE
feat: 카카오 클라이언트 서비스에 로깅 추가 및 로깅 포맷 일부 변경

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/auth/client/KakaoApiClientImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/client/KakaoApiClientImpl.java
@@ -2,6 +2,7 @@ package com.tamnara.backend.auth.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tamnara.backend.auth.constant.AuthResponseMessage;
 import com.tamnara.backend.auth.constant.KakaoOAuthConstant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,16 +15,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.*;
 
 import java.util.Map;
-
-import static com.tamnara.backend.auth.constant.AuthResponseMessage.EXTERNAL_API_TIMEOUT;
-import static com.tamnara.backend.auth.constant.AuthResponseMessage.PARSING_ACCESS_TOKEN_FAILS;
-import static com.tamnara.backend.auth.constant.AuthResponseMessage.PARSING_USER_INFO_FAILS;
 
 @Slf4j
 @Service
@@ -38,7 +32,11 @@ public class KakaoApiClientImpl implements KakaoApiClient {
 
     @Override
     public String getAccessToken(String code) {
+        String partialCode = code.substring(0, 4);
+        log.info("[AUTH] getAccessToken 시작 - code:{}", partialCode);
+
         try {
+
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
@@ -58,42 +56,55 @@ public class KakaoApiClientImpl implements KakaoApiClient {
             );
 
             Map<String, Object> body = objectMapper.readValue(response.getBody(), Map.class);
+
+            log.info("[AUTH] getAccessToken 완료 - code:{}", partialCode);
             return (String) body.get("access_token");
         } catch (HttpClientErrorException | HttpServerErrorException e) {
-            log.error("[ERROR] 카카오 응답 오류: status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
+            log.error("[AUTH] getAccessToken 카카오 응답 오류 - code:{}", partialCode);
             throw new RuntimeException("카카오 요청 실패", e);
         } catch (ResourceAccessException e) {
-            log.error("[ERROR] 카카오 연결 오류: {}", e.getMessage());
-            throw new RuntimeException(EXTERNAL_API_TIMEOUT, e);
+            log.error("[AUTH] getAccessToken 카카오 연결 오류 - code:{}", partialCode);
+            throw new RuntimeException(AuthResponseMessage.EXTERNAL_API_TIMEOUT, e);
         } catch (JsonProcessingException e) {
-            log.error("[ERROR] 카카오 토큰 파싱 실패", e);
-            throw new RuntimeException(PARSING_ACCESS_TOKEN_FAILS, e);
+            log.error("[AUTH] getAccessToken 카카오 토큰 파싱 실패 - code:{}", partialCode);
+            throw new RuntimeException(AuthResponseMessage.PARSING_ACCESS_TOKEN_FAILS, e);
         } catch (Exception e) {
-            log.error("[ERROR] 알 수 없는 예외 발생", e);
+            log.error("[AUTH] getAccessToken 알 수 없는 예외 발생 - code:{}", partialCode);
             throw new RuntimeException("알 수 없는 오류", e);
         }
     }
 
     @Override
     public Map<String, Object> getUserInfo(String accessToken) {
+        String partialToken = accessToken.substring(0, 4);
+        log.info("[AUTH] getUserInfo 시작 - accessToken: {}", partialToken);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(accessToken);
         HttpEntity<Void> request = new HttpEntity<>(headers);
 
-        ResponseEntity<String> response = restTemplate.exchange(
-                KakaoOAuthConstant.KAKAO_OAUTH_USER_INFO,
-                HttpMethod.GET,
-                request,
-                String.class
-        );
-
         try {
-            return objectMapper.readValue(response.getBody(), Map.class);
+            ResponseEntity<String> response = restTemplate.exchange(
+                    KakaoOAuthConstant.KAKAO_OAUTH_USER_INFO,
+                    HttpMethod.GET,
+                    request,
+                    String.class
+            );
+            log.info("[AUTH] getUserInfo 카카오 응답 반환 - accessToken: {}", partialToken);
+
+            Map<String, Object> userInfo = objectMapper.readValue(response.getBody(), Map.class);
+            log.info("[AUTH] getUserInfo 완료 - accessToken: {}", partialToken);
+
+            return userInfo;
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(PARSING_USER_INFO_FAILS, e);
+            log.error("[AUTH] getUserInfo Json 처리 실패 - accessToken: {}", partialToken);
+            throw new RuntimeException(AuthResponseMessage.PARSING_USER_INFO_FAILS, e);
         } catch (ResourceAccessException e) {
-            throw new RuntimeException(EXTERNAL_API_TIMEOUT, e);
+            log.error("[AUTH] getUserInfo 리소스 접근 실패 - accessToken: {}", partialToken);
+            throw new RuntimeException(AuthResponseMessage.EXTERNAL_API_TIMEOUT, e);
+        } catch (RestClientException e) {
+            log.error("[AUTH] getUserInfo 외부 API 호출 실패 - accessToken: {}", partialToken);
+            throw new RuntimeException(AuthResponseMessage.EXTERNAL_API_CALL_FAIL, e);
         }
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/auth/constant/AuthResponseMessage.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/constant/AuthResponseMessage.java
@@ -9,7 +9,8 @@ public final class AuthResponseMessage {
     public static final String KAKAO_BAD_GATEWAY = "카카오 서버 요청에 실패하였습니다.";
     public static final String PARSING_ACCESS_TOKEN_FAILS = "액세스 토큰 파싱에 실패했습니다.";
     public static final String PARSING_USER_INFO_FAILS = "액세스 토큰 파싱에 실패했습니다.";
-    public static final String EXTERNAL_API_TIMEOUT = "API 호출에 시간이 너무 오래 걸립니다.";
+    public static final String EXTERNAL_API_TIMEOUT = "외부 API 호출에 시간이 너무 오래 걸립니다.";
+    public static final String EXTERNAL_API_CALL_FAIL = "외부 API 호출에 실패했습니다.";
 
     public static final String NOT_LOGGED_IN = "로그인이 필요합니다.";
     public static final String IS_LOGGED_IN = "로그인 상태입니다.";

--- a/backend/src/main/java/com/tamnara/backend/auth/service/AuthServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/service/AuthServiceImpl.java
@@ -25,25 +25,25 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     public void refreshToken(HttpServletRequest request, HttpServletResponse response) {
-        log.info("[AUTH] refreshToken 요청 시작");
+        log.info("[AUTH] refreshToken 시작");
 
         String refreshToken = jwtProvider.resolveRefreshTokenFromCookie(request);
 
         if (refreshToken == null) {
-            log.warn("[AUTH] refreshToken 완료 — status={}, reason={}", "실패", "토큰 없음");
+            log.warn("[AUTH] refreshToken 실패 — reason:{}", "토큰 없음");
             throw new CustomException(HttpStatus.UNAUTHORIZED, AuthResponseMessage.REFRESH_TOKEN_INVALID);
         } else if (!jwtProvider.validateRefreshToken(refreshToken)) {
-            log.warn("[AUTH] refreshToken 완료 — status={}, reason={}", "실패", "유효하지 않은 토큰");
+            log.warn("[AUTH] refreshToken 실패 — reason:{}", "유효하지 않은 토큰");
             throw new CustomException(HttpStatus.UNAUTHORIZED, AuthResponseMessage.REFRESH_TOKEN_INVALID);
         }
 
         String userId = jwtProvider.getUserIdFromToken(refreshToken);
         User user = userRepository.findById(Long.parseLong(userId))
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
-        log.info("[AUTH] refreshToken 처리 중 — 회원 조회 완료, userId: {}", userId);
+        log.info("[AUTH] refreshToken 처리 중 — 회원 조회 완료, userId:{}", userId);
 
         String newAccessToken = jwtProvider.createAccessToken(user);
-        log.info("[AUTH] refreshToken 처리 중 - 새로운 Access Token 발급, userId: {}", userId);
+        log.info("[AUTH] refreshToken 처리 중 - 새로운 Access Token 발급, userId:{}", userId);
 
         Cookie newAccessCookie = new Cookie(JwtConstant.ACCESS_TOKEN, newAccessToken);
         newAccessCookie.setHttpOnly(true);
@@ -51,7 +51,7 @@ public class AuthServiceImpl implements AuthService {
         newAccessCookie.setPath("/");
         newAccessCookie.setMaxAge((int) JwtConstant.ACCESS_TOKEN_VALIDITY.toSeconds());
         response.addCookie(newAccessCookie);
-        log.info("[AUTH] refreshToken 처리 중 - 새로운 Access Token 쿠키 저장, userId: {}", userId);
+        log.info("[AUTH] refreshToken 처리 중 - 새로운 Access Token 쿠키 저장, userId:{}", userId);
 
         log.info("[AUTH] refreshToken() 완료 - status:{}", "성공");
     }

--- a/backend/src/main/java/com/tamnara/backend/auth/service/KakaoServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/auth/service/KakaoServiceImpl.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class KakaoServiceImpl implements KakaoService {
+public class KakaoServiceImpl implements KakaoService{
 
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
@@ -33,8 +33,8 @@ public class KakaoServiceImpl implements KakaoService {
     @Value("${kakao.redirect-uri}") private String redirectUri;
 
     @Override
-    public String buildKakaoLoginUrl() {
-        log.info("[AUTH] buildKakaoLoginUrl 요청 시작");
+    public String buildKakaoLoginUrl(){
+        log.info("[AUTH] buildKakaoLoginUrl 시작");
 
         String url = UriComponentsBuilder.fromUriString(KakaoOAuthConstant.KAKAO_OAUTH_AUTHORIZE)
                 .queryParam("response_type", "code")
@@ -49,14 +49,15 @@ public class KakaoServiceImpl implements KakaoService {
 
     @Override
     @Transactional
-    public void kakaoLogin(String code, HttpServletResponse response) {
-        log.info("[AUTH] kakaoLogin 요청 시작");
+    public void kakaoLogin(String code, HttpServletResponse response){
+        String partialCode = code.substring(0, 4);
+        log.info("[AUTH] kakaoLogin 시작 - code:{}", partialCode);
 
         String kakaoAccessToken = kakaoApiClient.getAccessToken(code);
-        log.info("[AUTH] kakaoLogin 처리 중 - 카카오 Access Token 발급 성공");
+        log.info("[AUTH] kakaoLogin 처리 중 - 카카오 Access Token 발급 성공, code:{}", partialCode);
 
         Map<String, Object> userInfoJson = kakaoApiClient.getUserInfo(kakaoAccessToken);
-        log.info("[AUTH] kakaoLogin 처리 중 - 카카오 사용자 정보 조회 성공");
+        log.info("[AUTH] kakaoLogin 처리 중 - 카카오 사용자 정보 조회 성공, code:{}", partialCode);
 
         Map<String, Object> kakaoAccount = (Map<String, Object>) userInfoJson.get("kakao_account");
         Map<String, Object> properties = (Map<String, Object>) userInfoJson.get("properties");
@@ -64,18 +65,18 @@ public class KakaoServiceImpl implements KakaoService {
         String kakaoId = String.valueOf(userInfoJson.get("id"));
         String email = (String) kakaoAccount.get("email");
         String nickname = (String) properties.get("nickname");
-        log.info("[AUTH] kakaoLogin 처리 중 - 카카오 사용자 파싱 완료, kakaoId={}", kakaoId);
+        log.info("[AUTH] kakaoLogin 처리 중 - 카카오 사용자 파싱 완료, code:{} kakaoId:{}", partialCode, kakaoId);
 
         Optional<User> optionalUser = userRepository.findByProviderAndProviderId("KAKAO", kakaoId);
         User user;
-        if (optionalUser.isPresent()) {
+        if (optionalUser.isPresent()){
             user = optionalUser.get();
-            if (user.getState().equals(State.DELETED)) {
+            if (user.getState().equals(State.DELETED)){
                 user.updateState(State.ACTIVE);
                 user.resetWithdrawnAtNull();
-                log.info("[AUTH] kakaoLogin 처리 중 - 탈퇴한 계정 복구, userId: {}", user.getId());
+                log.info("[AUTH] kakaoLogin 처리 중 - 탈퇴한 계정 복구, code:{} userId:{}", partialCode, user.getId());
             }
-        } else {
+        } else{
             user = optionalUser.orElseGet(() -> User.builder()
                 .email(email)
                 .username(nickname)
@@ -87,14 +88,14 @@ public class KakaoServiceImpl implements KakaoService {
         }
         user.updateLastActiveAtNow();
         userRepository.save(user);
-        log.info("[AUTH] kakaoLogin 처리 중 - 마지막 활동시간 업데이트 완료, userId: {}", user.getId());
+        log.info("[AUTH] kakaoLogin 처리 중 - 마지막 활동시간 업데이트 완료, code:{} userId:{}", partialCode, user.getId());
 
         String accessToken = jwtProvider.createAccessToken(user);
-        log.info("[AUTH] kakaoLogin 처리 중 - JWT Access Token 발급 완료, userId: {}", user.getId());
+        log.info("[AUTH] kakaoLogin 처리 중 - JWT Access Token 발급 완료, code:{} userId:{}", partialCode, user.getId());
 
         String refreshToken = jwtProvider.createRefreshToken(user);
         jwtProvider.saveRefreshToken(user, refreshToken);
-        log.info("[AUTH] kakaoLogin 처리 중 - JWT Refresh Token 발급 완료, userId: {}", user.getId());
+        log.info("[AUTH] kakaoLogin 처리 중 - JWT Refresh Token 발급 완료, code:{} userId:{}", partialCode, user.getId());
 
         Cookie accessCookie = new Cookie(JwtConstant.ACCESS_TOKEN, accessToken);
         accessCookie.setHttpOnly(true);
@@ -102,7 +103,7 @@ public class KakaoServiceImpl implements KakaoService {
         accessCookie.setPath("/");
         accessCookie.setMaxAge((int) JwtConstant.ACCESS_TOKEN_VALIDITY.getSeconds());
         response.addCookie(accessCookie);
-        log.info("[AUTH] kakaoLogin 처리 중 - 쿠키에 JWT Access Token 저장 완료, userId: {}", user.getId());
+        log.info("[AUTH] kakaoLogin 처리 중 - 쿠키에 JWT Access Token 저장 완료, code:{} userId:{}", partialCode, user.getId());
 
         Cookie refreshCookie = new Cookie(JwtConstant.REFRESH_TOKEN, refreshToken);
         refreshCookie.setHttpOnly(true);
@@ -110,8 +111,8 @@ public class KakaoServiceImpl implements KakaoService {
         refreshCookie.setPath("/");
         refreshCookie.setMaxAge((int) JwtConstant.REFRESH_TOKEN_VALIDITY.getSeconds());
         response.addCookie(refreshCookie);
-        log.info("[AUTH] kakaoLogin 처리 중 - 쿠키에 JWT Refresh Token 저장 완료: userId={}", user.getId());
+        log.info("[AUTH] kakaoLogin 처리 중 - 쿠키에 JWT Refresh Token 저장 완료, code:{} userId:{}", partialCode, user.getId());
 
-        log.info("[AUTH] kakaoLogin 완료 - userId: {}",  user.getId());
+        log.info("[AUTH] kakaoLogin 완료 - code:{} userId:{}", partialCode, user.getId());
     }
 }

--- a/backend/src/main/java/com/tamnara/backend/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/user/service/UserServiceImpl.java
@@ -37,7 +37,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public SignupResponse signup(SignupRequest requestDto) {
-        log.info("[USER] signup 요청 시작");
+        log.info("[USER] signup 시작");
         if (userRepository.existsByEmail(requestDto.getEmail())) {
             log.warn("[USER] signup 예외 처리 - state:{}", "이메일 중복");
             throw new DuplicateEmailException();
@@ -69,7 +69,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public boolean isEmailAvailable(String email) {
-        log.info("[USER] isEmailAvailable 요청 시작");
+        log.info("[USER] isEmailAvailable 시작");
 
         if (email == null || !email.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")) {
             log.warn("[USER] isEmailAvailable 예외 처리 - state:{}", "이메일 형식 오류");
@@ -83,7 +83,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserInfo getCurrentUserInfo(Long userId) {
-        log.info("[USER] getCurrentUserInfo 요청 시작 - userId: {}", userId);
+        log.info("[USER] getCurrentUserInfo 시작 - userId: {}", userId);
 
         User user = checkValidateUser(userId);
 
@@ -94,7 +94,7 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public User updateUsername(Long userId, String newUsername) {
-        log.info("[USER] updateUsername 요청 시작 - userId: {}", userId);
+        log.info("[USER] updateUsername 시작 - userId: {}", userId);
 
         User user = checkValidateUser(userId);
         user.updateUsername(newUsername);
@@ -105,7 +105,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public UserWithdrawInfo withdrawUser(Long userId, HttpServletResponse response) {
-        log.info("[USER] withdrawUser 요청 시작 - userId: {}", userId);
+        log.info("[USER] withdrawUser 시작 - userId: {}", userId);
 
         User user = checkValidateUser(userId);
 
@@ -123,7 +123,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void logout(Long userId, HttpServletResponse response) {
-        log.info("[USER] logout 요청 시작 - userId: {}", userId);
+        log.info("[USER] logout 시작 - userId: {}", userId);
 
         userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         log.info("[USER] logout 처리 중 - 회원 조회 성공, userId: {}", userId);
@@ -143,7 +143,7 @@ public class UserServiceImpl implements UserService {
      */
 
     private User checkValidateUser (Long userId) {
-        log.info("[USER] checkValidateUser 요청 시작 - userId: {}", userId);
+        log.info("[USER] checkValidateUser 시작 - userId: {}", userId);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, ResponseMessage.USER_NOT_FOUND));
@@ -160,7 +160,7 @@ public class UserServiceImpl implements UserService {
     }
 
     private void expireCookies(Long userId, HttpServletResponse response) {
-        log.info("[USER] expireCookies 요청 시작 - userId: {}", userId);
+        log.info("[USER] expireCookies 시작 - userId: {}", userId);
 
         Cookie expiredAccessCookie = new Cookie(JwtConstant.ACCESS_TOKEN, null);
         expiredAccessCookie.setHttpOnly(true);


### PR DESCRIPTION
## 연관된 이슈
#475 #476

<br/>

## 작업 내용
- [x] 카카오 클라이언트 서비스에 로깅 추가
- [x] 인증/회원 서비스 로직에 추가한 로깅의 포맷 일부 변경

<br/>

## 상세 내용
### 카카오 클라이언트 서비스에 로깅 추가
- **작업한 파일:** `auth.client.KakaoClientImpl`
- **작업 내용** : 로깅 포맷 변경 및 추가