### PR TITLE
fix: 투표 공개 상태 업데이트 서비스에서 공개 예정 투표가 없으면 early return 처리

### DIFF
--- a/backend/src/main/java/com/tamnara/backend/poll/service/PollServiceImpl.java
+++ b/backend/src/main/java/com/tamnara/backend/poll/service/PollServiceImpl.java
@@ -104,15 +104,6 @@ public class PollServiceImpl implements PollService {
     public void updatePollStates() {
         log.info("[POLL] updatePollStates 시작");
 
-        Optional<Poll> published = pollRepository.findLatestPollByPublishedPoll();
-        if (published.isPresent()) {
-            published.get().changeState(PollState.DELETED);
-            pollRepository.save(published.get());
-        } else {
-            log.warn("[POLL] updatePollStates 경고 - 투표 삭제 대상 없음(공개 중인 투표가 존재하지 않음)");
-        }
-        log.info("[POLL] updatePollStates 처리 중 - 기존 투표 삭제 성공");
-
         Optional<Poll> scheduled = pollRepository.findLatesPollByScheduledPoll();
         if (scheduled.isPresent()) {
             scheduled.get().changeState(PollState.PUBLISHED);
@@ -138,8 +129,18 @@ public class PollServiceImpl implements PollService {
             );
         } else {
             log.warn("[POLL] updatePollStates 경고 - 투표 공개 대상 없음(공개 예정인 투표가 존재하지 않음)");
+            return;
         }
         log.info("[POLL] updatePollStates 처리 중 - 신규 투표 공개 및 투표 알림 이벤트 발행 성공");
+
+        Optional<Poll> published = pollRepository.findLatestPollByPublishedPoll();
+        if (published.isPresent()) {
+            published.get().changeState(PollState.DELETED);
+            pollRepository.save(published.get());
+        } else {
+            log.warn("[POLL] updatePollStates 경고 - 투표 삭제 대상 없음(공개 중인 투표가 존재하지 않음)");
+        }
+        log.info("[POLL] updatePollStates 처리 중 - 기존 투표 삭제 성공");
 
         log.info("[POLL] updatePollStates 완료");
     }

--- a/backend/src/test/java/com/tamnara/backend/poll/service/PollServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/service/PollServiceImplTest.java
@@ -292,7 +292,8 @@ class PollServiceImplTest {
         pollServiceImpl.updatePollStates();
 
         // then
-        verify(pollRepository, never()).save(any(Poll.class));
+        verify(pollRepository, never()).findLatestPollByPublishedPoll();
+        verify(pollRepository, never()).save(any());
     }
 
     @Test

--- a/backend/src/test/java/com/tamnara/backend/poll/service/PollServiceImplTest.java
+++ b/backend/src/test/java/com/tamnara/backend/poll/service/PollServiceImplTest.java
@@ -402,7 +402,6 @@ class PollServiceImplTest {
     void vote_alreadyVoted() {
         // given
         when(pollRepository.findLatestPollByPublishedPoll()).thenReturn(Optional.of(poll));
-        when(pollOptionRepository.findAllById(List.of(101L))).thenReturn(List.of(option1));
         when(voteRepository.hasVotedLatestPublishedPoll(user.getId())).thenReturn(true);
 
         // when


### PR DESCRIPTION
## 연관된 이슈
#494 

<br/>

## 작업 내용
- [x] 투표 공개 상태 업데이트 서비스에서 공개 예정 투표가 없으면 early return 처리
- [x] `./gradlew build` 성공 확인

<br/>

## 상세 내용
### 투표 공개 상태 업데이트 서비스에서 공개 예정 투표가 없으면 early return 처리
- **작업한 파일:** `poll/service/PollServiceImpl`
- **작업 내용:**
   - `updatePollStates()`에서 투표 공개 처리 로직을 선행, 투표 삭제 처리 로직을 후행으로 로직 변경
   - `updatePollStates()`에서 공개 예정 투표가 없으면 earty return 처리